### PR TITLE
Fix dashboard fetch on initial load

### DIFF
--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -16,7 +16,7 @@ export default function DashboardView() {
 
   useEffect(() => {
     const fetchMonthlySales = async () => {
-      const start = new Date()
+      const start = new Date(selectedDate)
       start.setDate(1)
       const end = new Date(start)
       end.setMonth(end.getMonth() + 1)
@@ -50,7 +50,7 @@ export default function DashboardView() {
     }
 
     fetchMonthlySales()
-  }, [])
+  }, [selectedDate])
 
   useEffect(() => {
     const fetchFloorAndRegister = async () => {


### PR DESCRIPTION
## Summary
- ensure dashboard fetches data for the selected day and month

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684556bfd87883219ebf841f215e5042