### PR TITLE
Fix calendar locale crash

### DIFF
--- a/components/sales-input-view.tsx
+++ b/components/sales-input-view.tsx
@@ -195,8 +195,7 @@ ${data.remarks ? `備考: ${data.remarks}` : ""}`
                     mode="single"
                     selected={selectedDate}
                     onSelect={(date) => date && setSelectedDate(date)}
-                    locale="ja"
-                    locales={{ ja }}
+                    locale={ja}
                     initialFocus
                   />
                 </PopoverContent>


### PR DESCRIPTION
## Summary
- import date-fns `ja` locale and use it properly in SalesInputView

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461cebd67c8321b86bf21e6c6e7126