### PR TITLE
Improve AI analysis report handling

### DIFF
--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -41,7 +41,12 @@ export default function DashboardView() {
     ec_sales: number
   }[]>([])
 
-  const [aiComment, setAiComment] = useState<string | null>(null)
+  const [aiReport, setAiReport] = useState<{
+    summary: string
+    compare_recent: string
+    compare_last_year: string
+    top3: string
+  } | null>(null)
   const [aiLoading, setAiLoading] = useState<boolean>(true)
   const [aiError, setAiError] = useState<boolean>(false)
 
@@ -254,13 +259,12 @@ export default function DashboardView() {
         const res = await fetch('/api/analyze')
         if (!res.ok) throw new Error('fetch error')
         const data = await res.json()
-        let comment = ''
-        try {
-          comment = JSON.parse(data.result).result || ''
-        } catch {
-          comment = data.result
-        }
-        setAiComment(comment)
+        setAiReport({
+          summary: data.summary || '',
+          compare_recent: data.compare_recent || '',
+          compare_last_year: data.compare_last_year || '',
+          top3: data.top3 || '',
+        })
       } catch (e) {
         console.error(e)
         setAiError(true)
@@ -491,7 +495,26 @@ export default function DashboardView() {
           <CardContent className="p-4 text-sm text-gray-600">
             {aiLoading && <p>分析中...</p>}
             {aiError && !aiLoading && <p>取得に失敗しました</p>}
-            {!aiLoading && !aiError && <p>{aiComment}</p>}
+            {!aiLoading && !aiError && aiReport && (
+              <div className="space-y-4">
+                <div>
+                  <h4 className="font-semibold">簡易分析</h4>
+                  <p>{aiReport.summary}</p>
+                </div>
+                <div>
+                  <h4 className="font-semibold">前月・前々月との比較</h4>
+                  <p>{aiReport.compare_recent}</p>
+                </div>
+                <div>
+                  <h4 className="font-semibold">前年同月との比較</h4>
+                  <p>{aiReport.compare_last_year}</p>
+                </div>
+                <div>
+                  <h4 className="font-semibold">特異日ベスト3</h4>
+                  <p>{aiReport.top3}</p>
+                </div>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/pages/api/analyze.ts
+++ b/pages/api/analyze.ts
@@ -1,17 +1,86 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 import { supabase } from "../../lib/supabase"
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY!
+
+type Totals = { floor: number; ec: number; register: number }
+
+async function fetchMonthTotals(year: number, month: number): Promise<Totals> {
+  const start = new Date(year, month, 1)
+  const end = new Date(year, month + 1, 0)
+  const { data, error } = await supabase
+    .from("daily_sales_report")
+    .select(
+      "floor_sales, register_count, amazon_amount, rakuten_amount, yahoo_amount, mercari_amount, base_amount, qoo10_amount"
+    )
+    .gte("date", start.toISOString().split("T")[0])
+    .lte("date", end.toISOString().split("T")[0])
+
+  if (error || !data) {
+    console.error(error)
+    return { floor: 0, ec: 0, register: 0 }
+  }
+
+  return (data || []).reduce(
+    (acc, row) => {
+      acc.floor += row.floor_sales || 0
+      acc.register += row.register_count || 0
+      acc.ec +=
+        (row.amazon_amount || 0) +
+        (row.rakuten_amount || 0) +
+        (row.yahoo_amount || 0) +
+        (row.mercari_amount || 0) +
+        (row.base_amount || 0) +
+        (row.qoo10_amount || 0)
+      return acc
+    },
+    { floor: 0, ec: 0, register: 0 },
+  )
+}
+
+async function callOpenAI(system: string, content: string): Promise<string> {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4-1106-preview",
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content },
+      ],
+      max_tokens: 100,
+      temperature: 0.5,
+    }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    console.error(text)
+    throw new Error("Failed to call OpenAI")
+  }
+
+  const json = await res.json()
+  const msg = json.choices?.[0]?.message?.content?.trim() || ""
+  try {
+    return JSON.parse(msg).result || msg
+  } catch {
+    return msg
+  }
+}
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
   try {
     const now = new Date()
     const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
       .toISOString()
       .split("T")[0]
+    const todayStr = now.toISOString().split("T")[0]
 
     const { data, error } = await supabase
       .from("daily_sales_report")
@@ -19,6 +88,7 @@ export default async function handler(
         "date, floor_sales, amazon_amount, rakuten_amount, yahoo_amount, mercari_amount, base_amount, qoo10_amount"
       )
       .gte("date", startOfMonth)
+      .lte("date", todayStr)
       .order("date", { ascending: true })
 
     if (error || !data) {
@@ -26,7 +96,7 @@ export default async function handler(
       return res.status(500).json({ error: "Failed to fetch data" })
     }
 
-    const summary = data.map((d) => ({
+    const summaryData = data.map((d) => ({
       date: d.date,
       floor: d.floor_sales,
       ec:
@@ -38,38 +108,99 @@ export default async function handler(
         d.qoo10_amount,
     }))
 
-    const openaiRes = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({
-        model: "gpt-4-1106-preview",
-        messages: [
-          {
-            role: "system",
-            content:
-              "You are a helpful assistant. Provide a short Japanese comment about the provided sales data. Respond only with JSON like { \"result\": \"...\" }.",
-          },
-          { role: "user", content: JSON.stringify(summary) },
-        ],
-        max_tokens: 100,
-        temperature: 0.5,
-      }),
-    })
+    const summaryComment = await callOpenAI(
+      "You are a helpful assistant. Provide a short Japanese comment about the provided sales data. Respond only with JSON like { \"result\": \"...\" }.",
+      JSON.stringify(summaryData),
+    )
 
-    if (!openaiRes.ok) {
-      const text = await openaiRes.text()
-      console.error(text)
-      return res.status(500).json({ error: "Failed to call OpenAI" })
+    // Determine month end
+    const tomorrow = new Date(now)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    const isMonthEnd = tomorrow.getDate() === 1
+
+    let compareRecentComment = ""
+    let compareLastYearComment = ""
+    let top3Comment = ""
+
+    if (isMonthEnd) {
+      const thisTotals = await fetchMonthTotals(now.getFullYear(), now.getMonth())
+      const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+      const lastTotals = await fetchMonthTotals(
+        lastMonth.getFullYear(),
+        lastMonth.getMonth(),
+      )
+      const prevMonth = new Date(now.getFullYear(), now.getMonth() - 2, 1)
+      const prevTotals = await fetchMonthTotals(
+        prevMonth.getFullYear(),
+        prevMonth.getMonth(),
+      )
+
+      const compareRecentData = [
+        {
+          month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`,
+          ...thisTotals,
+        },
+        {
+          month: `${lastMonth.getFullYear()}-${String(lastMonth.getMonth() + 1).padStart(2, "0")}`,
+          ...lastTotals,
+        },
+        {
+          month: `${prevMonth.getFullYear()}-${String(prevMonth.getMonth() + 1).padStart(2, "0")}`,
+          ...prevTotals,
+        },
+      ]
+
+      compareRecentComment = await callOpenAI(
+        "You are a helpful assistant. Compare the provided monthly totals and give a short Japanese comment. Respond only with JSON like { \"result\": \"...\" }.",
+        JSON.stringify(compareRecentData),
+      )
+
+      const lastYear = new Date(now.getFullYear() - 1, now.getMonth(), 1)
+      const lastYearTotals = await fetchMonthTotals(
+        lastYear.getFullYear(),
+        lastYear.getMonth(),
+      )
+
+      const compareLastYearData = [
+        {
+          month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`,
+          ...thisTotals,
+        },
+        {
+          month: `${lastYear.getFullYear()}-${String(lastYear.getMonth() + 1).padStart(2, "0")}`,
+          ...lastYearTotals,
+        },
+      ]
+
+      compareLastYearComment = await callOpenAI(
+        "You are a helpful assistant. Compare this month's totals with the same month last year and provide a short Japanese comment. Respond only with JSON like { \"result\": \"...\" }.",
+        JSON.stringify(compareLastYearData),
+      )
+
+      const totals = summaryData.map((d) => ({
+        date: d.date,
+        total: d.floor + d.ec,
+      }))
+      const avg =
+        totals.reduce((sum, t) => sum + t.total, 0) / (totals.length || 1)
+      const picked = totals
+        .map((t) => ({ ...t, diff: Math.abs(t.total - avg) }))
+        .sort((a, b) => b.diff - a.diff)
+        .slice(0, 3)
+        .map(({ date, total }) => ({ date, total }))
+
+      top3Comment = await callOpenAI(
+        "You are a helpful assistant. Identify the days where sales were exceptionally high or low. Respond only with JSON like { \"result\": \"...\" }.",
+        JSON.stringify(picked),
+      )
     }
 
-    const openaiJson = await openaiRes.json()
-    const comment =
-      openaiJson.choices?.[0]?.message?.content?.trim() || ""
-
-    res.status(200).json({ result: comment })
+    res.status(200).json({
+      summary: summaryComment,
+      compare_recent: compareRecentComment,
+      compare_last_year: compareLastYearComment,
+      top3: top3Comment,
+    })
   } catch (err) {
     console.error(err)
     res.status(500).json({ error: "Internal Server Error" })


### PR DESCRIPTION
## Summary
- expand `/api/analyze` with month-end logic and multiple OpenAI calls
- adjust dashboard view to render structured AI analysis

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684646922d108321a0ebf39961a9ce6b