### PR TITLE
Adjust AI summary output to plain text

### DIFF
--- a/pages/api/analyze.ts
+++ b/pages/api/analyze.ts
@@ -38,7 +38,11 @@ async function fetchMonthTotals(year: number, month: number): Promise<Totals> {
   )
 }
 
-async function callOpenAI(system: string, content: string): Promise<string> {
+async function callOpenAI(
+  system: string,
+  content: string,
+  parse: boolean = true,
+): Promise<string> {
   const res = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
     headers: {
@@ -64,6 +68,9 @@ async function callOpenAI(system: string, content: string): Promise<string> {
 
   const json = await res.json()
   const msg = json.choices?.[0]?.message?.content?.trim() || ""
+  if (!parse) {
+    return msg
+  }
   try {
     return JSON.parse(msg).result || msg
   } catch {
@@ -109,8 +116,9 @@ export default async function handler(
     }))
 
     const summaryComment = await callOpenAI(
-      "You are a helpful assistant. Provide a short Japanese comment about the provided sales data. Respond only with JSON like { \"result\": \"...\" }.",
+      "You are a helpful assistant. Provide a short Japanese comment about the provided sales data. Respond only with plain Japanese text and do not use JSON or markdown.",
       JSON.stringify(summaryData),
+      false,
     )
 
     // Determine month end


### PR DESCRIPTION
## Summary
- modify `callOpenAI` helper to optionally skip JSON parsing
- request plain Japanese text for summary comment

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684648908d248321820c5a3ba42ef609