### PR TITLE
Fix AI report layout

### DIFF
--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -515,27 +515,27 @@ export default function DashboardView() {
               <div className="space-y-4">
                 <div>
                   <h4 className="font-semibold">簡易分析</h4>
-                  <p className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+                  <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed max-w-full overflow-visible">
                     {aiReport.summary}
-                  </p>
+                  </pre>
                 </div>
                 <div>
                   <h4 className="font-semibold">前月・前々月との比較</h4>
-                  <p className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+                  <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed max-w-full overflow-visible">
                     {compareRecent || aiReport.compare_recent}
-                  </p>
+                  </pre>
                 </div>
                 <div>
                   <h4 className="font-semibold">前年同月との比較</h4>
-                  <p className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+                  <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed max-w-full overflow-visible">
                     {aiReport.compare_last_year}
-                  </p>
+                  </pre>
                 </div>
                 <div>
                   <h4 className="font-semibold">特異日ベスト3</h4>
-                  <p className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+                  <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed max-w-full overflow-visible">
                     {aiReport.top3}
-                  </p>
+                  </pre>
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary
- display AI report text inside `<pre>` blocks for better wrapping

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467af58ecc83219bfe595c6ce778ec