### PR TITLE
Update max_tokens for OpenAI API

### DIFF
--- a/pages/api/analyze.ts
+++ b/pages/api/analyze.ts
@@ -55,7 +55,7 @@ async function callOpenAI(
         { role: "system", content: system },
         { role: "user", content },
       ],
-      max_tokens: 100,
+      max_tokens: 800,
       temperature: 0.5,
     }),
   })


### PR DESCRIPTION
## Summary
- increase allowed tokens when calling OpenAI

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468e931b8883218de0ed787f751bac