### PR TITLE
Implement Google OAuth with allowed emails

### DIFF
--- a/hooks/use-auth.tsx
+++ b/hooks/use-auth.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react"
+import { supabase } from "../lib/supabase"
+import { isAllowed } from "../lib/supabase"
+
+export const useAuth = () => {
+  const [user, setUser] = useState<any>(null)
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user || !isAllowed(data.user.email)) {
+        supabase.auth.signOut()
+        location.href = "/login"
+      } else {
+        setUser(data.user)
+      }
+    })
+  }, [])
+  return user
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -6,6 +6,11 @@ const supabaseAnonKey =
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
+export const ALLOWED_EMAILS = ["ts@ai.aizu-tv.com"]
+
+export const isAllowed = (email?: string) =>
+  ALLOWED_EMAILS.includes((email || "").toLowerCase())
+
 export type SalesData = {
   id?: string
   date: string

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+import { isAllowed } from "./lib/supabase"
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next()
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { global: { headers: { cookie: req.headers.get("cookie")! } } }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.redirect(new URL("/login", req.url))
+  if (!isAllowed(user.email)) {
+    await supabase.auth.signOut()
+    return NextResponse.redirect(new URL("/login", req.url))
+  }
+  return res
+}
+
+export const config = {
+  matcher: ["/((?!api|login|_next|favicon.ico).*)"],
+}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,18 @@
+import { useRouter } from "next/router"
+import { supabase } from "../lib/supabase"
+
+export default function Login() {
+  const router = useRouter()
+  const handleSignIn = () =>
+    supabase.auth.signInWithOAuth({ provider: "google" })
+  return (
+    <div className="h-screen flex items-center justify-center">
+      <button
+        className="px-6 py-3 bg-blue-600 text-white rounded"
+        onClick={handleSignIn}
+      >
+        Google でログイン
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- configure supabase utils with allowed emails check
- add login page for Google OAuth
- enforce auth via middleware
- provide `useAuth` hook for pages to access the user

## Testing
- `pnpm build` *(fails: next not found because node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846cee447008321aa5516557ccbe8e7