### PR TITLE
Update middleware with try-catch

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,20 +1,17 @@
-// middleware.ts
 import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-/* ───── Supabase 接続情報（固定ベタ書き） ───── */
 const SUPABASE_URL = 'https://zrerpexdsaxqztqqrwwv.supabase.co'
 const SUPABASE_KEY =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InpyZXJwZXhkc2F4cXp0cXFyd3d2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkzNjAzOTgsImV4cCI6MjA2NDkzNjM5OH0.nVWvJfsSAC7dnNCuXLxoN5OvQ4ShQI5FOwipkMlKNec'
 
-/* ───── 許可メール ───── */
 const ALLOWED_EMAILS = ['aizubrandhall@gmail.com']
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()
 
-  /* Google から返る 1 回目のリダイレクト (?code=xxx) はスキップ */
+  // Google から返る最初の ?code=xxx はスキップ
   if (req.nextUrl.searchParams.has('code')) return res
 
   const supabase = createMiddlewareClient({
@@ -24,18 +21,20 @@ export async function middleware(req: NextRequest) {
     supabaseKey: SUPABASE_KEY,
   })
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  try {
+    const { data: { user } } = await supabase.auth.getUser()
 
-  if (!user || !ALLOWED_EMAILS.includes(user.email ?? '')) {
-    return NextResponse.redirect(new URL('/unauthorized', req.url))
+    if (!user || !ALLOWED_EMAILS.includes(user.email ?? '')) {
+      return NextResponse.redirect(new URL('/unauthorized', req.url))
+    }
+  } catch {
+    // Cookie なし・タイムアウトなどはログインへ
+    return NextResponse.redirect(new URL('/login', req.url))
   }
 
   return res
 }
 
-/* /login と /unauthorized だけはミドルウェア対象外 */
 export const config = {
   matcher: ['/((?!_next/|favicon.ico|login|unauthorized).*)'],
 }


### PR DESCRIPTION
## Summary
- update `middleware.ts` to handle auth errors gracefully

## Testing
- `npx next lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_6847b84fe3a08321b11634be40880533