### PR TITLE
Add Vercel project config to disable frozen-lockfile

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "installCommand": "pnpm install --no-frozen-lockfile",
+  "buildCommand": "next build"
+}


### PR DESCRIPTION
## Summary
- disable pnpm `--frozen-lockfile` for Vercel builds by defining `.vercel/project.json`

## Testing
- `git status --short`
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_6847bc7d43188321af6da406cf6d7e1f