### PR TITLE
Update analyze endpoint and dashboard view

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -8,7 +8,8 @@ const OPENAI_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
 export async function POST(req: Request) {
   try {
     // ------- input -------
-    const { date } = await req.json();             // 例: "2025-06-13"
+    const body = await req.json().catch(() => ({}));
+    const date = (body.date ?? new Date().toISOString().slice(0, 10)) as string; // 例: "2025-06-13"
     const month = date.slice(0, 7);                // "yyyy-MM"
 
     // ------- env -------

--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -565,7 +565,7 @@ export default function DashboardView() {
                 <div>
                   <h4 className="font-semibold text-lg">分析結果</h4>
                   <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed max-w-full overflow-visible">
-                    {latestAiReport || "分析結果がありません。「AI分析を実行」ボタンを押して分析を開始してください。"}
+                    {latestAiReport ?? "分析結果がありません。「AI分析を実行」ボタンを押して分析を開始してください。"}
                   </pre>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- handle missing date in `/api/analyze` by defaulting to today
- keep console error logging
- tweak AI report display condition

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc2d72e588321848139dac45b5441