### PR TITLE
Fix AI report display when empty

### DIFF
--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -565,7 +565,9 @@ export default function DashboardView() {
                 <div>
                   <h4 className="font-semibold text-lg">分析結果</h4>
                   <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed max-w-full overflow-visible">
-                    {latestAiReport ?? "分析結果がありません。「AI分析を実行」ボタンを押して分析を開始してください。"}
+                    {latestAiReport?.trim()
+                      ? latestAiReport
+                      : '分析結果がありません。「AI分析を実行」ボタンを押して分析を開始してください。'}
                   </pre>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- handle empty AI report text

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcad321f083219ca14a45a84bb964