### PR TITLE
Add next-auth and logout button

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { BarChart3, Edit, Plus } from "lucide-react"
+import { signOut, useSession } from "next-auth/react"
 
 type NavigationItem = "dashboard" | "input" | "edit"
 
@@ -11,6 +12,7 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
+  const { data: session } = useSession()
   const navigationItems = [
     {
       id: "dashboard" as NavigationItem,
@@ -56,8 +58,16 @@ export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
         </div>
       </nav>
 
-      <div className="p-4 border-t border-gray-700">
-        <p className="text-xs text-gray-400">会津ブランド館</p>
+  <div className="p-4 border-t border-gray-700">
+        <p className="text-xs text-gray-400 mb-2">会津ブランド館</p>
+        {session && (
+          <div className="flex flex-col space-y-2">
+            <p className="text-xs text-gray-300">{session.user?.email}</p>
+            <Button variant="ghost" className="w-full" onClick={() => signOut()}>
+              ログアウト
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "latest",
     "ws": "latest",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "next-auth": "latest"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-auth:
+        specifier: latest
+        version: 4.24.7(next@15.2.4)(react@19.0.0)
       openai:
         specifier: latest
         version: 5.3.0(ws@8.18.2)(zod@3.24.1)
@@ -3229,6 +3232,12 @@ snapshots:
 
   next-themes@0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
+  next-auth@4.24.7(next@15.2.4)(react@19.0.0):
+    dependencies:
+      next: 15.2.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 


### PR DESCRIPTION
## Summary
- install next-auth dependency (manual lock update)
- show logout button in the sidebar using signOut and useSession

## Testing
- `pnpm build` *(fails: next not installed)*
- `pnpm install` *(fails: 403 from registry)*


------
https://chatgpt.com/codex/tasks/task_e_684bdbdc27608321b866a02d28a8ae78