### PR TITLE
Implement NextAuth login and style

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,33 @@
+import NextAuth, { type NextAuthOptions } from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+
+const allowedEmails = ["aizubrandhall@gmail.com"];
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "GOOGLE_CLIENT_ID",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "GOOGLE_CLIENT_SECRET",
+    }),
+  ],
+  callbacks: {
+    async signIn({ user }) {
+      return allowedEmails.includes((user.email ?? "").toLowerCase());
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        (session as any).role = allowedEmails.includes((session.user.email ?? "").toLowerCase()) ? "admin" : "user";
+      }
+      return session;
+    },
+    async jwt({ token }) {
+      if (token.email) {
+        (token as any).role = allowedEmails.includes(token.email.toLowerCase()) ? "admin" : "user";
+      }
+      return token;
+    },
+  },
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import Providers from '../components/providers'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -14,7 +15,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   )
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,17 +1,22 @@
-'use client'
-import { supabase } from '@/lib/supabase'
+"use client"
+import { signIn } from "next-auth/react"
 
 export default function Login() {
   return (
-    <div className="flex h-screen items-center justify-center">
-      <button
-        className="rounded bg-black px-6 py-3 text-white"
-        onClick={() =>
-          supabase.auth.signInWithOAuth({ provider: 'google' })
-        }
-      >
-        Google でログイン
-      </button>
+    <div className="flex min-h-screen items-start justify-center pt-20 bg-gray-100">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-8 shadow">
+        <h1 className="mb-2 text-center text-2xl font-bold">TSAログイン画面</h1>
+        <p className="mb-6 text-center text-sm text-gray-500">Technical Staff AI System</p>
+        <p className="mb-4 text-center">Googleアカウントでログインしてください</p>
+        <div className="flex justify-center">
+          <button
+            className="rounded bg-blue-600 px-6 py-3 font-medium text-white hover:bg-blue-700"
+            onClick={() => signIn("google")}
+          >
+            Googleでログイン
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,0 +1,6 @@
+"use client"
+import { SessionProvider } from "next-auth/react"
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,8 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { BarChart3, Edit, Plus } from "lucide-react"
-import { useEffect, useState } from "react"
-import { supabase } from "@/lib/supabase"
+import { useSession, signOut } from "next-auth/react"
 
 type NavigationItem = "dashboard" | "input" | "edit"
 
@@ -13,21 +12,7 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
-  const [session, setSession] = useState<any | null>(null)
-
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session)
-    })
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, sess) => {
-      setSession(sess)
-    })
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [])
+  const { data: session } = useSession()
   const navigationItems = [
     {
       id: "dashboard" as NavigationItem,
@@ -80,7 +65,7 @@ export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
         <Button
           className="fixed bottom-4 left-4 z-50"
           variant="secondary"
-          onClick={() => supabase.auth.signOut()}
+          onClick={() => signOut({ callbackUrl: '/' })}
         >
           ログアウト
         </Button>

--- a/hooks/use-auth.tsx
+++ b/hooks/use-auth.tsx
@@ -1,18 +1,7 @@
-import { useEffect, useState } from "react"
-import { supabase } from "../lib/supabase"
-import { isAllowed } from "../lib/supabase"
+"use client"
+import { useSession } from "next-auth/react"
 
 export const useAuth = () => {
-  const [user, setUser] = useState<any>(null)
-  useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => {
-      if (!data.user || !isAllowed(data.user.email)) {
-        supabase.auth.signOut()
-        location.href = "/login"
-      } else {
-        setUser(data.user)
-      }
-    })
-  }, [])
-  return user
+  const { data: session } = useSession()
+  return session?.user ?? null
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,35 +1,14 @@
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
-import { NextResponse } from 'next/server'
-import type { NextRequest } from 'next/server'
+import { withAuth } from "next-auth/middleware"
 
-const SUPABASE_URL = 'https://zrerpexdsaxqztqqrwwv.supabase.co'
-const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9…KNec'
-const ALLOWED = ['aizubrandhall@gmail.com']
-
-export async function middleware(req: NextRequest) {
-  const res = NextResponse.next()
-
-  // Google リダイレクト最初の ?code=xxx はスキップ
-  if (req.nextUrl.searchParams.has('code')) return res
-
-  const supabase = createMiddlewareClient({
-    req,
-    res,
-    supabaseUrl: SUPABASE_URL,
-    supabaseKey: SUPABASE_KEY,
-  })
-
-  try {
-    const { data: { user } } = await supabase.auth.getUser()
-    if (!user || !ALLOWED.includes(user.email ?? '')) {
-      return NextResponse.redirect(new URL('/login', req.url))
-    }
-  } catch {
-    return NextResponse.redirect(new URL('/login', req.url))
-  }
-  return res
-}
+export default withAuth({
+  pages: {
+    signIn: "/login",
+  },
+  callbacks: {
+    authorized: ({ token }) => !!token,
+  },
+})
 
 export const config = {
-  matcher: ['/', '/((?!_next/|favicon.ico|login|unauthorized).*)'],
+  matcher: ["/", "/((?!_next/|favicon.ico|login).*)"],
 }


### PR DESCRIPTION
## Summary
- add NextAuth route and middleware for Google login
- create session provider and wrap the app layout
- redesign login page with centered panel
- update sidebar logout to use NextAuth
- simplify auth hook for NextAuth

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be7ce348c83219e18bd96aa099f9b