### PR TITLE
Fix login loop with NextAuth

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -11,6 +11,8 @@ const authorize = ({ email }: { email?: string }): UserInfo | null => {
 }
 
 export const authOptions: NextAuthOptions = {
+  secret: process.env.NEXTAUTH_SECRET ?? "next-auth-secret",
+  trustHost: true,
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID ?? "GOOGLE_CLIENT_ID",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
-import Providers from '../components/providers'
+import { SessionProvider } from "next-auth/react"
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -16,7 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <Providers>{children}</Providers>
+        <SessionProvider>{children}</SessionProvider>
       </body>
     </html>
   )

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,6 +1,0 @@
-"use client"
-import { SessionProvider } from "next-auth/react"
-
-export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
-}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { withAuth } from "next-auth/middleware"
 
 export default withAuth({
+  secret: process.env.NEXTAUTH_SECRET ?? "next-auth-secret",
   pages: {
     signIn: "/login",
   },


### PR DESCRIPTION
## Summary
- wrap app with `SessionProvider`
- configure `authOptions` with secret and `trustHost`
- ensure middleware uses same secret
- remove unused provider component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684beecfaec48321931cf11a82a5ee45