### PR TITLE
Fix login routing loop

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,4 @@
+import AdminDashboard from "@/admin-dashboard";
+export default function DashboardPage() {
+  return <AdminDashboard />;
+}

--- a/app/login/LoginButton.tsx
+++ b/app/login/LoginButton.tsx
@@ -1,0 +1,12 @@
+"use client"
+import { signIn } from "next-auth/react"
+export default function LoginButton() {
+  return (
+    <button
+      className="rounded bg-blue-600 px-6 py-3 font-medium text-white hover:bg-blue-700"
+      onClick={() => signIn("google")}
+    >
+      Googleでログイン
+    </button>
+  )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,15 +1,13 @@
-"use client"
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { signIn, useSession } from "next-auth/react"
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import LoginButton from "./LoginButton";
 
-export default function Login() {
-  const { data: session } = useSession()
-  const router = useRouter()
-
-  useEffect(() => {
-    if (session) router.replace("/dashboard")
-  }, [session, router])
+export default async function LoginPage() {
+  const session = await getServerSession(authOptions);
+  if (session) {
+    redirect("/dashboard");
+  }
 
   return (
     <div className="flex min-h-screen items-start justify-center pt-20 bg-gray-100">
@@ -18,14 +16,9 @@ export default function Login() {
         <p className="mb-6 text-center text-sm text-gray-500">Technical Staff AI System</p>
         <p className="mb-4 text-center">Googleアカウントでログインしてください</p>
         <div className="flex justify-center">
-          <button
-            className="rounded bg-blue-600 px-6 py-3 font-medium text-white hover:bg-blue-700"
-            onClick={() => signIn("google")}
-          >
-            Googleでログイン
-          </button>
+          <LoginButton />
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,16 +1,19 @@
-import { withAuth } from "next-auth/middleware"
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
 
-export default withAuth({
-  pages: {
-    signIn: "/login",
-  },
-  callbacks: {
-    authorized: ({ token }) => !!token,
-  },
-})
+export async function middleware(req: NextRequest) {
+  const token = await getToken({ req });
+  const isLoggedIn = token && token.email === "aizubrandhall@gmail.com";
+
+  if (!isLoggedIn) {
+    const loginUrl = new URL("/login", req.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
 
 export const config = {
-  matcher: [
-    "/((?!api|_next/static|_next/image|favicon.ico|login|auth).*)",
-  ],
-}
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|login|auth).*)"],
+};


### PR DESCRIPTION
## Summary
- redirect logged-in users away from the login page
- check session token in middleware and redirect to login when absent or unauthorized
- add Dashboard route
- move login button logic into a small client component

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: many missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684c11d5e7f883219c66ede0714c6201