### PR TITLE
Add logout button and header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,20 @@
 import './globals.css'
-import { Providers } from '@/components/providers'
+import Header from '@/components/Header'
+import { SessionProvider } from 'next-auth/react'
+
+export const metadata = {
+  title: '売上報告システム',
+  description: '帳票の分析と集計',
+}
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
       <body>
-        <Providers>{children}</Providers>
+        <SessionProvider>
+          <Header />
+          <main className="p-4">{children}</main>
+        </SessionProvider>
       </body>
     </html>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import LogoutButton from './LogoutButton'
+import { useSession } from 'next-auth/react'
+
+export default function Header() {
+  const { data: session } = useSession()
+
+  return (
+    <header className="flex justify-between items-center px-4 py-2 border-b border-gray-200 bg-white">
+      <h1 className="text-lg font-bold text-blue-600">売上報告システム</h1>
+      <div className="flex items-center gap-4">
+        {session?.user?.name && (
+          <span className="text-sm text-gray-700">{session.user.name}</span>
+        )}
+        <LogoutButton />
+      </div>
+    </header>
+  )
+}

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { signOut } from 'next-auth/react'
+import { LogOut } from 'lucide-react'
+
+export default function LogoutButton() {
+  return (
+    <button
+      onClick={() => signOut()}
+      className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-full shadow-sm hover:bg-gray-700 hover:text-white transition"
+    >
+      <LogOut size={16} />
+      ログアウト
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a LogoutButton component
- add a Header component with user name and logout button
- update the app root layout to include Header and SessionProvider

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b23a16c8321a4c24ef7a4c63d4b