### PR TITLE
Fix missing Header component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,15 @@
 import './globals.css'
 import { Providers } from '@/components/providers'
+import Header from '@/components/Header'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <Header />
+          {children}
+        </Providers>
       </body>
     </html>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { signOut } from 'next-auth/react'
+import { Button } from '@/components/ui/button'
+
+export default function Header() {
+  return (
+    <header className="w-full bg-gray-900 text-white p-4 flex items-center justify-between">
+      <h1 className="text-lg font-semibold">売上報告システム</h1>
+      <Button variant="secondary" onClick={() => signOut({ callbackUrl: '/' })}>
+        ログアウト
+      </Button>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add missing `Header` component
- include `Header` in main layout

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1dc90d7c83219103d58c2c91fb1d