### PR TITLE
Move logout to header and cleanup EC sales

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,14 +1,25 @@
 "use client";
-import { signOut } from 'next-auth/react'
+import { useSession, signOut } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
+import { LogOut } from 'lucide-react'
 
 export default function Header() {
+  const { data: session } = useSession()
+
   return (
     <header className="w-full bg-gray-900 text-white p-4 flex items-center justify-between">
       <h1 className="text-lg font-semibold">売上報告システム</h1>
-      <Button variant="secondary" onClick={() => signOut({ callbackUrl: '/' })}>
-        ログアウト
-      </Button>
+      {session && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm">{session.user.name}</span>
+          <Button
+            className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-full shadow-sm hover:bg-gray-700 hover:text-white transition"
+            onClick={() => signOut({ callbackUrl: '/' })}
+          >
+            <LogOut className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
     </header>
   )
 }

--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -359,11 +359,6 @@ export default function DashboardView() {
           <Button onClick={handleGenerate} className="mb-1 text-xs">
             売上報告を生成
           </Button>
-          {ecTotalAmount !== null && (
-            <div className="text-sm text-right font-semibold text-gray-700 mb-2">
-              今日のEC売上合計：{formatCurrency(ecTotalAmount)}
-            </div>
-          )}
         </div>
       </div>
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button"
 import { BarChart3, Edit, Plus } from "lucide-react"
-import { useSession, signOut } from "next-auth/react"
 
 type NavigationItem = "dashboard" | "input" | "edit"
 
@@ -12,7 +11,6 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
-  const { data: session } = useSession()
   const navigationItems = [
     {
       id: "dashboard" as NavigationItem,
@@ -61,15 +59,6 @@ export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
       <div className="p-4 border-t border-gray-700">
         <p className="text-xs text-gray-400">会津ブランド館</p>
       </div>
-      {session && (
-        <Button
-          className="fixed bottom-4 left-4 z-50"
-          variant="secondary"
-          onClick={() => signOut({ callbackUrl: '/' })}
-        >
-          ログアウト
-        </Button>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- adjust header to show logged in user and a rounded logout button
- drop duplicate logout button from sidebar
- remove duplicate EC sales total text

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1f8b5da483219ee2acbd567f23a7