### PR TITLE
Implement sales report result display

### DIFF
--- a/components/GenerateButton.tsx
+++ b/components/GenerateButton.tsx
@@ -1,33 +1,46 @@
 'use client'
 
 import { useState } from 'react'
+import { Button } from './ui/button'
 
 export default function GenerateButton() {
   const [loading, setLoading] = useState(false)
-  const [result, setResult] = useState('')
+  const [markdown, setMarkdown] = useState('')
 
   const handleClick = async () => {
     setLoading(true)
-    const res = await fetch('/api/analyze', { method: 'POST' })
-    const json = await res.json()
-    if (json.ok) setResult(json.markdown)
-    setLoading(false)
+    try {
+      const res = await fetch('/api/analyze', { method: 'POST' })
+      const json = await res.json()
+      if (json.ok) {
+        setMarkdown(json.markdown ?? json.result ?? '')
+      } else {
+        console.error(json.error)
+      }
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <button
-        onClick={handleClick}
-        disabled={loading}
-        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
-      >
+    <div className="flex flex-col gap-2">
+      <Button onClick={handleClick} disabled={loading} className="w-max">
         {loading ? '生成中…' : '売上報告を生成'}
-      </button>
-      {result && (
-        <div className="prose bg-white p-4 rounded border">
-          <pre>{result}</pre>
-        </div>
-      )}
+      </Button>
+      <div>
+        <h3 className="text-sm font-semibold mb-1">売上報告結果</h3>
+        {loading ? (
+          <p>生成中…</p>
+        ) : (
+          markdown && (
+            <pre className="whitespace-pre-wrap bg-white p-4 rounded border">
+              {markdown}
+            </pre>
+          )
+        )}
+      </div>
     </div>
   )
 }

--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -8,6 +8,7 @@ import { supabase } from "../lib/supabase"
 import { formatDateJST } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { toast } from "@/components/ui/use-toast"
+import GenerateButton from "./GenerateButton"
 
 export default function DashboardView() {
   const [monthlySales, setMonthlySales] = useState<number | null>(null)
@@ -284,12 +285,6 @@ export default function DashboardView() {
     fetchCompare()
   }, [selectedDate])
 
-  const handleGenerate = async () => {
-    const res = await fetch(`/api/report?date=${formatDateJST(selectedDate)}`)
-    const txt = await res.text()
-    await navigator.clipboard.writeText(txt)
-    alert("売上報告をコピーしました")
-  }
 
   const formatCurrency = (amount: number) =>
     new Intl.NumberFormat("ja-JP", {
@@ -356,9 +351,7 @@ export default function DashboardView() {
             onChange={(e) => setSelectedDate(new Date(e.target.value))}
             className="border rounded text-xs p-1 mb-1 mr-2"
           />
-          <Button onClick={handleGenerate} className="mb-1 text-xs">
-            売上報告を生成
-          </Button>
+          <GenerateButton />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- show generated sales report on dashboard
- add GenerateButton component logic to fetch `/api/analyze`
- integrate GenerateButton into the dashboard view

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*
- `vercel dev` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2c9e7d848321b7c3d1f99c91583f