### PR TITLE
Fix auto-copy sales report

### DIFF
--- a/components/GenerateReportButton.tsx
+++ b/components/GenerateReportButton.tsx
@@ -5,14 +5,13 @@ import { Button } from './ui/button'
 
 export default function GenerateReportButton() {
   const [loading, setLoading] = useState(false)
-  const [report, setReport] = useState<string | null>(null)
 
-  const generate = async () => {
+  const handleClick = async () => {
     setLoading(true)
     try {
       const res = await fetch('/api/report', { method: 'POST' })
       const text = await res.text()
-      setReport(text)
+      await navigator.clipboard.writeText(text)
     } catch (e) {
       console.error(e)
     } finally {
@@ -20,22 +19,8 @@ export default function GenerateReportButton() {
     }
   }
 
-  const copy = async () => {
-    if (!report) return
-    try {
-      await navigator.clipboard.writeText(report)
-      console.log('コピーしました')
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
-  return report ? (
-    <Button onClick={copy} className="w-max">
-      コピーする
-    </Button>
-  ) : (
-    <Button onClick={generate} disabled={loading} className="w-max">
+  return (
+    <Button onClick={handleClick} disabled={loading} className="w-max">
       {loading ? '生成中…' : '売上報告を生成'}
     </Button>
   )


### PR DESCRIPTION
## Summary
- copy generated sales report to clipboard automatically

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3656eb9483218d5de2d270a8ca5c