### PR TITLE
Add WEB sales management system UI

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import AdminDashboard from "@/admin-dashboard";
+import MainDashboard from "@/main-dashboard";
 export default function DashboardPage() {
-  return <AdminDashboard />;
+  return <MainDashboard />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
-import AdminDashboard from "../admin-dashboard"
+import { redirect } from "next/navigation"
 
 export default function Page() {
-  return <AdminDashboard />
+  redirect("/dashboard")
+  return null
 }

--- a/components/common-dashboard.tsx
+++ b/components/common-dashboard.tsx
@@ -1,0 +1,28 @@
+"use client"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+const dummy = [
+  { site: "Amazon", count: 120, amount: 100000 },
+  { site: "BASE", count: 80, amount: 50000 },
+  { site: "Yahoo", count: 40, amount: 30000 },
+  { site: "楽天", count: 70, amount: 60000 },
+]
+
+export default function CommonDashboard() {
+  const f = (n: number) => new Intl.NumberFormat("ja-JP").format(n)
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      {dummy.map((d) => (
+        <Card key={d.site}>
+          <CardHeader>
+            <CardTitle className="text-sm">{d.site}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <div className="text-xl font-bold">{f(d.count)} 件</div>
+            <div className="text-sm text-gray-500">¥{f(d.amount)}</div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/components/main-sidebar.tsx
+++ b/components/main-sidebar.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { signOut } from "next-auth/react"
+import { Button } from "@/components/ui/button"
+
+export type ModuleId = "sales" | "web"
+
+interface Props {
+  active: ModuleId
+  onChange: (m: ModuleId) => void
+}
+
+const items = [
+  { id: "sales" as ModuleId, label: "売上報告システム" },
+  { id: "web" as ModuleId, label: "WEB販売管理システム" },
+]
+
+export default function MainSidebar({ active, onChange }: Props) {
+  return (
+    <div className="w-64 bg-gray-800 text-white h-screen fixed left-0 top-0 flex flex-col">
+      <div className="p-4 border-b border-gray-700">
+        <h1 className="text-lg font-semibold">TSAシステム</h1>
+      </div>
+      <nav className="flex-1 p-4 space-y-2">
+        {items.map((item) => (
+          <Button
+            key={item.id}
+            variant={active === item.id ? "secondary" : "ghost"}
+            className={`w-full justify-start text-sm h-10 ${
+              active === item.id ? "bg-gray-700 text-white" : "text-gray-300 hover:text-white hover:bg-gray-800"
+            }`}
+            onClick={() => onChange(item.id)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </nav>
+      <div className="p-4 border-t border-gray-700">
+        <Button onClick={() => signOut({ callbackUrl: '/' })} className="w-full justify-center text-sm">
+          ログアウト
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -30,7 +30,7 @@ export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
   ]
 
   return (
-    <div className="w-64 bg-gray-900 text-white h-screen fixed left-0 top-0 flex flex-col">
+    <div className="w-64 bg-gray-900 text-white h-full fixed left-64 top-0 flex flex-col">
       <div className="p-6 border-b border-gray-700">
         <h1 className="text-lg font-semibold">売上報告システム</h1>
       </div>

--- a/components/websales-analysis.tsx
+++ b/components/websales-analysis.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+export default function WebSalesAnalysis({ month }: { month: string }) {
+  return (
+    <div>
+      <p>gpt-4o-mini に {month} のデータを渡して要約を表示予定。</p>
+    </div>
+  )
+}

--- a/components/websales-dashboard.tsx
+++ b/components/websales-dashboard.tsx
@@ -1,0 +1,105 @@
+"use client"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  LineChart,
+  Line,
+  Legend,
+} from "recharts"
+
+const productData = [
+  { month: "1月", sales: 30 },
+  { month: "2月", sales: 45 },
+  { month: "3月", sales: 40 },
+  { month: "4月", sales: 50 },
+  { month: "5月", sales: 55 },
+  { month: "6月", sales: 60 },
+]
+
+const siteData = [
+  { month: "1月", Amazon: 10, BASE: 5, Yahoo: 8, 楽天: 12 },
+  { month: "2月", Amazon: 12, BASE: 7, Yahoo: 9, 楽天: 15 },
+  { month: "3月", Amazon: 15, BASE: 8, Yahoo: 7, 楽天: 10 },
+  { month: "4月", Amazon: 14, BASE: 9, Yahoo: 10, 楽天: 12 },
+  { month: "5月", Amazon: 16, BASE: 10, Yahoo: 11, 楽天: 18 },
+  { month: "6月", Amazon: 18, BASE: 12, Yahoo: 9, 楽天: 20 },
+]
+
+const compareData = [
+  { month: "1月", current: 30, lastYear: 25 },
+  { month: "2月", current: 45, lastYear: 40 },
+  { month: "3月", current: 40, lastYear: 38 },
+  { month: "4月", current: 50, lastYear: 45 },
+  { month: "5月", current: 55, lastYear: 50 },
+  { month: "6月", current: 60, lastYear: 55 },
+]
+
+export default function WebSalesDashboard({ month }: { month: string }) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>商品別売上推移</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={productData}>
+                  <XAxis dataKey="month" />
+                  <YAxis />
+                  <Tooltip />
+                  <Bar dataKey="sales" fill="#3b82f6" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>サイト別売上推移</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={siteData}>
+                  <XAxis dataKey="month" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Line type="monotone" dataKey="Amazon" stroke="#3b82f6" />
+                  <Line type="monotone" dataKey="BASE" stroke="#10b981" />
+                  <Line type="monotone" dataKey="Yahoo" stroke="#f43f5e" />
+                  <Line type="monotone" dataKey="楽天" stroke="#f59e0b" />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>前年同月との比較（個数）</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={compareData}>
+                <XAxis dataKey="month" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="current" fill="#3b82f6" />
+                <Bar dataKey="lastYear" fill="#94a3b8" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/websales-edit.tsx
+++ b/components/websales-edit.tsx
@@ -1,0 +1,18 @@
+"use client"
+import { Button } from "@/components/ui/button"
+
+export default function WebSalesEdit({ month }: { month: string }) {
+  const handleDelete = () => {
+    if (confirm(`${month} のデータを削除しますか？`)) {
+      alert("削除しました")
+    }
+  }
+
+  return (
+    <div>
+      <Button variant="destructive" onClick={handleDelete}>
+        指定月データを一括削除
+      </Button>
+    </div>
+  )
+}

--- a/components/websales-input.tsx
+++ b/components/websales-input.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+
+export default function WebSalesInput({ month }: { month: string }) {
+  const [file, setFile] = useState<File | null>(null)
+  const [rows, setRows] = useState<{ product: string; qty: number; site: string }[]>([])
+
+  const handleAnalyze = () => {
+    if (file) {
+      setRows([{ product: "サンプル", qty: 10, site: "Amazon" }])
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+      <Button onClick={handleAnalyze}>AIで解析してDB登録</Button>
+      {rows.length > 0 && (
+        <table className="min-w-full text-sm border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-2 py-1 border">商品</th>
+              <th className="px-2 py-1 border">個数</th>
+              <th className="px-2 py-1 border">サイト</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i} className="text-center">
+                <td className="border px-2 py-1">{r.product}</td>
+                <td className="border px-2 py-1">{r.qty}</td>
+                <td className="border px-2 py-1">{r.site}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/components/websales-sidebar.tsx
+++ b/components/websales-sidebar.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { BarChart3, Upload, Trash2, Brain } from "lucide-react"
+
+export type WebView = "dashboard" | "input" | "edit" | "analysis"
+
+interface Props {
+  activeView: WebView
+  onViewChange: (v: WebView) => void
+}
+
+const items = [
+  { id: "dashboard" as WebView, label: "ダッシュボード", icon: BarChart3 },
+  { id: "input" as WebView, label: "入力", icon: Upload },
+  { id: "edit" as WebView, label: "修正", icon: Trash2 },
+  { id: "analysis" as WebView, label: "AI分析", icon: Brain },
+]
+
+export default function WebSalesSidebar({ activeView, onViewChange }: Props) {
+  return (
+    <div className="w-64 bg-gray-900 text-white h-full fixed left-64 top-0 flex flex-col">
+      <div className="p-6 border-b border-gray-700">
+        <h1 className="text-lg font-semibold">WEB販売管理</h1>
+      </div>
+      <nav className="flex-1 p-4 space-y-2">
+        {items.map((item) => {
+          const Icon = item.icon
+          return (
+            <Button
+              key={item.id}
+              variant={activeView === item.id ? "secondary" : "ghost"}
+              className={`w-full justify-start text-sm h-10 ${
+                activeView === item.id ? "bg-gray-700 text-white" : "text-gray-300 hover:text-white hover:bg-gray-800"
+              }`}
+              onClick={() => onViewChange(item.id)}
+            >
+              <Icon className="mr-3 h-4 w-4" />
+              {item.label}
+            </Button>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}

--- a/main-dashboard.tsx
+++ b/main-dashboard.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useState } from "react"
+import MainSidebar, { ModuleId } from "./components/main-sidebar"
+import SalesReportApp from "./sales-report-app"
+import WebSalesApp from "./web-sales-app"
+
+export default function MainDashboard() {
+  const [module, setModule] = useState<ModuleId>("sales")
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <MainSidebar active={module} onChange={setModule} />
+      <main className="flex-1 ml-64 overflow-auto">
+        {module === "sales" && <SalesReportApp />}
+        {module === "web" && <WebSalesApp />}
+      </main>
+    </div>
+  )
+}

--- a/sales-report-app.tsx
+++ b/sales-report-app.tsx
@@ -5,10 +5,11 @@ import Sidebar from "./components/sidebar"
 import DashboardView from "./components/dashboard-view"
 import SalesInputView from "./components/sales-input-view"
 import SalesEditView from "./components/sales-edit-view"
+import CommonDashboard from "./components/common-dashboard"
 
 type NavigationItem = "dashboard" | "input" | "edit"
 
-export default function AdminDashboard() {
+export default function SalesReportApp() {
   const [activeView, setActiveView] = useState<NavigationItem>("dashboard")
 
   const renderContent = () => {
@@ -25,12 +26,15 @@ export default function AdminDashboard() {
   }
 
   return (
-    <div className="flex h-screen bg-gray-50">
+    <div className="flex h-full">
       <Sidebar activeView={activeView} onViewChange={setActiveView} />
 
-      <main className="flex-1 ml-64 overflow-auto">
-        <div className="p-8">{renderContent()}</div>
-      </main>
+      <div className="flex-1 ml-64 overflow-auto">
+        <div className="p-8 space-y-8">
+          <CommonDashboard />
+          {renderContent()}
+        </div>
+      </div>
     </div>
   )
 }

--- a/web-sales-app.tsx
+++ b/web-sales-app.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useState } from "react"
+import WebSalesSidebar from "./components/websales-sidebar"
+import WebSalesDashboard from "./components/websales-dashboard"
+import WebSalesInput from "./components/websales-input"
+import WebSalesEdit from "./components/websales-edit"
+import WebSalesAnalysis from "./components/websales-analysis"
+import CommonDashboard from "./components/common-dashboard"
+
+export type WebView = "dashboard" | "input" | "edit" | "analysis"
+
+export default function WebSalesApp() {
+  const [activeView, setActiveView] = useState<WebView>("dashboard")
+  const [month, setMonth] = useState<string>(new Date().toISOString().slice(0, 7))
+
+  const renderContent = () => {
+    switch (activeView) {
+      case "dashboard":
+        return <WebSalesDashboard month={month} />
+      case "input":
+        return <WebSalesInput month={month} />
+      case "edit":
+        return <WebSalesEdit month={month} />
+      case "analysis":
+        return <WebSalesAnalysis month={month} />
+      default:
+        return <WebSalesDashboard month={month} />
+    }
+  }
+
+  return (
+    <div className="flex h-full">
+      <WebSalesSidebar activeView={activeView} onViewChange={setActiveView} />
+      <div className="flex-1 ml-64 overflow-auto">
+        <div className="p-8 space-y-8">
+          <div className="flex justify-end">
+            <input
+              type="month"
+              value={month}
+              onChange={(e) => setMonth(e.target.value)}
+              className="border rounded text-sm p-1"
+            />
+          </div>
+          <CommonDashboard />
+          {renderContent()}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a global dashboard menu with logout button
- create `WEB販売管理システム` module alongside the existing report system
- provide dummy charts, file upload, delete and AI analysis placeholders
- include a shared dashboard card component
- redirect `/` to `/dashboard`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd0461d6c83219ac76fc35e8c6fd3