### PR TITLE
Add summary of April 2025 web sales

### DIFF
--- a/components/websales-summary-cards.tsx
+++ b/components/websales-summary-cards.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { supabase } from "../lib/supabase"
+
+const SITES = [
+  { key: "amazon", name: "Amazon" },
+  { key: "rakuten", name: "楽天" },
+  { key: "yahoo", name: "Yahoo" },
+  { key: "mercari", name: "メルカリ" },
+  { key: "base", name: "BASE" },
+  { key: "qoo10", name: "Qoo10" },
+  { key: "floor", name: "フロア" },
+]
+
+type Totals = Record<string, { count: number; amount: number }>
+
+export default function WebSalesSummaryCards() {
+  const [totals, setTotals] = useState<Totals | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data, error } = await supabase
+        .from("web_sales")
+        .select(
+          "created_at, price, amazon, rakuten, yahoo, mercari, base, qoo10, floor"
+        )
+        .gte("created_at", "2025-04-01")
+        .lte("created_at", "2025-04-30")
+
+      if (error) {
+        console.error("fetch_error", error)
+        return
+      }
+
+      const init: Totals = {}
+      SITES.forEach((s) => {
+        init[s.key] = { count: 0, amount: 0 }
+      })
+
+      ;(data || []).forEach((row: any) => {
+        SITES.forEach((s) => {
+          const qty = row[s.key] ?? 0
+          const price = row.price ?? 0
+          init[s.key].count += qty
+          init[s.key].amount += qty * price
+        })
+      })
+
+      setTotals(init)
+    }
+
+    fetchData()
+  }, [])
+
+  const f = (n: number) => new Intl.NumberFormat("ja-JP").format(n)
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7 gap-4">
+      {SITES.map((s) => (
+        <Card key={s.key}>
+          <CardHeader>
+            <CardTitle className="text-sm">{s.name}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <div className="text-xl font-bold">
+              {totals ? f(totals[s.key].count) : "-"} 件
+            </div>
+            <div className="text-sm text-gray-500">
+              ¥{totals ? f(totals[s.key].amount) : "-"}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+

--- a/web-sales-app.tsx
+++ b/web-sales-app.tsx
@@ -7,6 +7,7 @@ import WebSalesInput from "./components/websales-input"
 import WebSalesEdit from "./components/websales-edit"
 import WebSalesAnalysis from "./components/websales-analysis"
 import CommonDashboard from "./components/common-dashboard"
+import WebSalesSummaryCards from "./components/websales-summary-cards"
 
 export type WebView = "dashboard" | "input" | "edit" | "analysis"
 
@@ -42,6 +43,7 @@ export default function WebSalesApp() {
               className="border rounded text-sm p-1"
             />
           </div>
+          <WebSalesSummaryCards />
           <CommonDashboard />
           {renderContent()}
         </div>


### PR DESCRIPTION
## Summary
- query April 2025 data from `web_sales`
- compute totals by mall and display them in cards
- show the summary at the top of the Web sales dashboard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd6eea7f08321aa4807c045f13279