### PR TITLE
Implement monthly product rankings

### DIFF
--- a/components/websales-ranking-table.tsx
+++ b/components/websales-ranking-table.tsx
@@ -14,7 +14,8 @@ interface Row {
 }
 
 export default function WebSalesRankingTable({ month }: Props) {
-  const [rows, setRows] = useState<Row[]>([])
+  const [bestRows, setBestRows] = useState<Row[]>([])
+  const [worstRows, setWorstRows] = useState<Row[]>([])
 
   useEffect(() => {
     const fetchData = async () => {
@@ -63,8 +64,10 @@ export default function WebSalesRankingTable({ month }: Props) {
         total_amount: v.amount,
       }))
 
-      arr.sort((a, b) => b.total_count - a.total_count)
-      setRows(arr.slice(0, 10))
+      const desc = [...arr].sort((a, b) => b.total_count - a.total_count)
+      const asc = [...arr].sort((a, b) => a.total_count - b.total_count)
+      setBestRows(desc.slice(0, 20))
+      setWorstRows(asc.slice(0, 10))
     }
 
     fetchData()
@@ -73,27 +76,53 @@ export default function WebSalesRankingTable({ month }: Props) {
   const f = (n: number) => new Intl.NumberFormat("ja-JP").format(n)
 
   return (
-    <div>
-      <table className="min-w-full text-sm border">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="border px-2 py-1">順位</th>
-            <th className="border px-2 py-1">商品名</th>
-            <th className="border px-2 py-1">件数</th>
-            <th className="border px-2 py-1">売上</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r, i) => (
-            <tr key={r.product_name} className="text-center">
-              <td className="border px-2 py-1">{i + 1}位</td>
-              <td className="border px-2 py-1 text-left">{r.product_name}</td>
-              <td className="border px-2 py-1">{f(r.total_count)}</td>
-              <td className="border px-2 py-1">¥{f(r.total_amount)}</td>
+    <div className="space-y-6">
+      <div>
+        <h3 className="font-semibold mb-2">ベスト20</h3>
+        <table className="min-w-full text-sm border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border px-2 py-1">順位</th>
+              <th className="border px-2 py-1">商品名</th>
+              <th className="border px-2 py-1">件数</th>
+              <th className="border px-2 py-1">売上金額</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {bestRows.map((r, i) => (
+              <tr key={r.product_name} className="text-center">
+                <td className="border px-2 py-1">{i + 1}位</td>
+                <td className="border px-2 py-1 text-left">{r.product_name}</td>
+                <td className="border px-2 py-1">{f(r.total_count)}</td>
+                <td className="border px-2 py-1">¥{f(r.total_amount)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">ワースト10</h3>
+        <table className="min-w-full text-sm border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border px-2 py-1">順位</th>
+              <th className="border px-2 py-1">商品名</th>
+              <th className="border px-2 py-1">件数</th>
+              <th className="border px-2 py-1">売上金額</th>
+            </tr>
+          </thead>
+          <tbody>
+            {worstRows.map((r, i) => (
+              <tr key={r.product_name} className="text-center">
+                <td className="border px-2 py-1">{i + 1}位</td>
+                <td className="border px-2 py-1 text-left">{r.product_name}</td>
+                <td className="border px-2 py-1">{f(r.total_count)}</td>
+                <td className="border px-2 py-1">¥{f(r.total_amount)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }

--- a/sales-report-app.tsx
+++ b/sales-report-app.tsx
@@ -5,7 +5,6 @@ import Sidebar from "./components/sidebar"
 import DashboardView from "./components/dashboard-view"
 import SalesInputView from "./components/sales-input-view"
 import SalesEditView from "./components/sales-edit-view"
-import CommonDashboard from "./components/common-dashboard"
 
 type NavigationItem = "dashboard" | "input" | "edit"
 
@@ -30,10 +29,7 @@ export default function SalesReportApp() {
       <Sidebar activeView={activeView} onViewChange={setActiveView} />
 
       <div className="flex-1 ml-64 overflow-auto">
-        <div className="p-8 space-y-8">
-          <CommonDashboard />
-          {renderContent()}
-        </div>
+        <div className="p-8 space-y-8">{renderContent()}</div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- remove unused Web sales cards from SalesReport dashboard
- show best 20 and worst 10 product rankings for Web sales

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cddf17bd4832192f4cb948c429769