### PR TITLE
Add site trend chart

### DIFF
--- a/components/websales-dashboard.tsx
+++ b/components/websales-dashboard.tsx
@@ -7,10 +7,8 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  LineChart,
-  Line,
-  Legend,
 } from "recharts"
+import WebSalesSiteTrend from "./websales-site-trend"
 
 const productData = [
   { month: "1月", sales: 30 },
@@ -21,14 +19,6 @@ const productData = [
   { month: "6月", sales: 60 },
 ]
 
-const siteData = [
-  { month: "1月", Amazon: 10, BASE: 5, Yahoo: 8, 楽天: 12 },
-  { month: "2月", Amazon: 12, BASE: 7, Yahoo: 9, 楽天: 15 },
-  { month: "3月", Amazon: 15, BASE: 8, Yahoo: 7, 楽天: 10 },
-  { month: "4月", Amazon: 14, BASE: 9, Yahoo: 10, 楽天: 12 },
-  { month: "5月", Amazon: 16, BASE: 10, Yahoo: 11, 楽天: 18 },
-  { month: "6月", Amazon: 18, BASE: 12, Yahoo: 9, 楽天: 20 },
-]
 
 const compareData = [
   { month: "1月", current: 30, lastYear: 25 },
@@ -60,27 +50,7 @@ export default function WebSalesDashboard({ month }: { month: string }) {
             </div>
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>サイト別売上推移</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={siteData}>
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Line type="monotone" dataKey="Amazon" stroke="#3b82f6" />
-                  <Line type="monotone" dataKey="BASE" stroke="#10b981" />
-                  <Line type="monotone" dataKey="Yahoo" stroke="#f43f5e" />
-                  <Line type="monotone" dataKey="楽天" stroke="#f59e0b" />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
+        <WebSalesSiteTrend />
       </div>
       <Card>
         <CardHeader>

--- a/components/websales-site-trend.tsx
+++ b/components/websales-site-trend.tsx
@@ -1,0 +1,118 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts"
+import { supabase } from "../lib/supabase"
+
+const SITES = [
+  { key: "amazon", name: "Amazon", color: "#3b82f6" },
+  { key: "rakuten", name: "楽天", color: "#f59e0b" },
+  { key: "yahoo", name: "Yahoo", color: "#f43f5e" },
+  { key: "mercari", name: "メルカリ", color: "#8b5cf6" },
+  { key: "base", name: "BASE", color: "#10b981" },
+  { key: "qoo10", name: "Qoo10", color: "#6366f1" },
+]
+
+type ChartRow = { month: string } & Record<string, number>
+
+export default function WebSalesSiteTrend() {
+  const [products, setProducts] = useState<string[]>([])
+  const [product, setProduct] = useState<string>("")
+  const [data, setData] = useState<ChartRow[]>([])
+
+  useEffect(() => {
+    const loadProducts = async () => {
+      const { data, error } = await supabase.from("web_sales").select("product_name")
+      if (error) {
+        console.error("load_products", error)
+        return
+      }
+      const names = Array.from(new Set((data || []).map((r: any) => r.product_name).filter(Boolean))).sort()
+      setProducts(names)
+      if (names.length > 0) setProduct(names[0])
+    }
+    loadProducts()
+  }, [])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!product) {
+        setData([])
+        return
+      }
+      const end = new Date()
+      end.setDate(1)
+      end.setHours(0, 0, 0, 0)
+      const start = new Date(end)
+      start.setMonth(start.getMonth() - 5)
+
+      const { data, error } = await supabase
+        .from("web_sales")
+        .select("created_at, amazon, rakuten, yahoo, mercari, base, qoo10")
+        .eq("product_name", product)
+        .gte("created_at", start.toISOString())
+        .lt("created_at", new Date(end.getFullYear(), end.getMonth() + 1, 1).toISOString())
+
+      if (error) {
+        console.error("fetch_error", error)
+        return
+      }
+
+      const map: Record<string, ChartRow> = {}
+      for (let i = 0; i < 6; i++) {
+        const d = new Date(start)
+        d.setMonth(start.getMonth() + i)
+        const key = `${d.getFullYear()}/${("0" + (d.getMonth() + 1)).slice(-2)}`
+        map[key] = { month: key }
+        SITES.forEach((s) => (map[key][s.key] = 0))
+      }
+
+      ;(data || []).forEach((row: any) => {
+        const d = new Date(row.created_at)
+        const key = `${d.getFullYear()}/${("0" + (d.getMonth() + 1)).slice(-2)}`
+        const item = map[key]
+        if (!item) return
+        SITES.forEach((s) => {
+          item[s.key] += row[s.key] ?? 0
+        })
+      })
+
+      setData(Object.values(map))
+    }
+    fetchData()
+  }, [product])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>サイト別売上推移</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <select
+          value={product}
+          onChange={(e) => setProduct(e.target.value)}
+          className="border rounded p-1 text-sm"
+        >
+          {products.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} margin={{ left: 10, right: 10 }}>
+              <XAxis dataKey="month" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              {SITES.map((s) => (
+                <Bar key={s.key} dataKey={s.key} stackId="a" fill={s.color} />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- add `WebSalesSiteTrend` component to display 6-month mall totals
- integrate chart into `websales-dashboard`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce1225be083218497e9b0731d061d