### PR TITLE
Organize routes for sales modules

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,0 @@
-import MainDashboard from "@/main-dashboard";
-export default function DashboardPage() {
-  return <MainDashboard />;
-}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation"
 
 export default function Page() {
-  redirect("/dashboard")
+  redirect("/sales/dashboard")
   return null
 }

--- a/app/sales/ai/page.tsx
+++ b/app/sales/ai/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+import Sidebar from "@/components/sidebar"
+
+export default function SalesAiPage() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1 ml-64 p-8 space-y-8">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-2">AI分析</h2>
+        <p className="text-sm text-gray-600">AI分析機能は準備中です。</p>
+      </div>
+    </div>
+  )
+}

--- a/app/sales/dashboard/page.tsx
+++ b/app/sales/dashboard/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+import Sidebar from "@/components/sidebar"
+import DashboardView from "@/components/dashboard-view"
+
+export default function SalesDashboardPage() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1 ml-64 p-8 space-y-8">
+        <DashboardView />
+      </div>
+    </div>
+  )
+}

--- a/app/sales/edit/page.tsx
+++ b/app/sales/edit/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+import Sidebar from "@/components/sidebar"
+import SalesEditView from "@/components/sales-edit-view"
+
+export default function SalesEditPage() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1 ml-64 p-8 space-y-8">
+        <SalesEditView />
+      </div>
+    </div>
+  )
+}

--- a/app/sales/input/page.tsx
+++ b/app/sales/input/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+import Sidebar from "@/components/sidebar"
+import SalesInputView from "@/components/sales-input-view"
+
+export default function SalesInputPage() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1 ml-64 p-8 space-y-8">
+        <SalesInputView />
+      </div>
+    </div>
+  )
+}

--- a/app/web-sales/ai/page.tsx
+++ b/app/web-sales/ai/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 import { useState } from "react"
 import Sidebar from "@/components/sidebar"
-import WebSalesInput from "@/components/websales-input"
+import WebSalesAnalysis from "@/components/websales-analysis"
 
-export default function WebSalesInputPage() {
+export default function WebSalesAiPage() {
   const [month, setMonth] = useState<string>(new Date().toISOString().slice(0, 7))
   return (
     <div className="flex min-h-screen">
@@ -17,7 +17,7 @@ export default function WebSalesInputPage() {
             className="border rounded text-sm p-1"
           />
         </div>
-        <WebSalesInput month={month} />
+        <WebSalesAnalysis month={month} />
       </div>
     </div>
   )

--- a/app/web-sales/dashboard/page.tsx
+++ b/app/web-sales/dashboard/page.tsx
@@ -1,0 +1,30 @@
+"use client"
+import { useState } from "react"
+import Sidebar from "@/components/sidebar"
+import WebSalesDashboard from "@/components/websales-dashboard"
+import WebSalesSummaryCards from "@/components/websales-summary-cards"
+import WebSalesRankingTable from "@/components/websales-ranking-table"
+import CommonDashboard from "@/components/common-dashboard"
+
+export default function WebSalesDashboardPage() {
+  const [month, setMonth] = useState<string>(new Date().toISOString().slice(0, 7))
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex-1 ml-64 overflow-auto p-8 space-y-8">
+        <div className="flex justify-end">
+          <input
+            type="month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className="border rounded text-sm p-1"
+          />
+        </div>
+        <WebSalesSummaryCards month={month} />
+        <WebSalesRankingTable month={month} />
+        <CommonDashboard />
+        <WebSalesDashboard month={month} />
+      </div>
+    </div>
+  )
+}

--- a/app/web-sales/edit/page.tsx
+++ b/app/web-sales/edit/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 import { useState } from "react"
 import Sidebar from "@/components/sidebar"
-import WebSalesInput from "@/components/websales-input"
+import WebSalesEdit from "@/components/websales-edit"
 
-export default function WebSalesInputPage() {
+export default function WebSalesEditPage() {
   const [month, setMonth] = useState<string>(new Date().toISOString().slice(0, 7))
   return (
     <div className="flex min-h-screen">
@@ -17,7 +17,7 @@ export default function WebSalesInputPage() {
             className="border rounded text-sm p-1"
           />
         </div>
-        <WebSalesInput month={month} />
+        <WebSalesEdit month={month} />
       </div>
     </div>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,14 +1,19 @@
 "use client";
 import { useSession, signOut } from 'next-auth/react'
+import { usePathname } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { LogOut } from 'lucide-react'
 
 export default function Header() {
   const { data: session } = useSession()
+  const pathname = usePathname()
+  const title = pathname.startsWith('/web-sales')
+    ? 'WEB販売管理システム'
+    : '売上報告システム'
 
   return (
     <header className="w-full bg-gray-900 text-white p-4 flex items-center justify-between">
-      <h1 className="text-lg font-semibold">売上報告システム</h1>
+      <h1 className="text-lg font-semibold">{title}</h1>
       {session && (
         <div className="flex items-center gap-2">
           <span className="text-sm">{session.user.name}</span>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,64 +1,64 @@
 "use client"
 
+import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { BarChart3, Edit, Plus } from "lucide-react"
+import { BarChart3, Plus, Edit, Brain, Upload } from "lucide-react"
 
-type NavigationItem = "dashboard" | "input" | "edit"
+const sections = [
+  {
+    title: "売上報告システム",
+    items: [
+      { label: "ダッシュボード", href: "/sales/dashboard", icon: BarChart3 },
+      { label: "入力", href: "/sales/input", icon: Plus },
+      { label: "修正", href: "/sales/edit", icon: Edit },
+      { label: "AI分析", href: "/sales/ai", icon: Brain },
+    ],
+  },
+  {
+    title: "WEB販売管理システム",
+    items: [
+      { label: "ダッシュボード", href: "/web-sales/dashboard", icon: BarChart3 },
+      { label: "入力", href: "/web-sales/input", icon: Upload },
+      { label: "修正", href: "/web-sales/edit", icon: Edit },
+      { label: "AI分析", href: "/web-sales/ai", icon: Brain },
+    ],
+  },
+] as const
 
-interface SidebarProps {
-  activeView: NavigationItem
-  onViewChange: (view: NavigationItem) => void
-}
-
-export default function Sidebar({ activeView, onViewChange }: SidebarProps) {
-  const navigationItems = [
-    {
-      id: "dashboard" as NavigationItem,
-      label: "ダッシュボード",
-      icon: BarChart3,
-    },
-    {
-      id: "input" as NavigationItem,
-      label: "売上入力",
-      icon: Plus,
-    },
-    {
-      id: "edit" as NavigationItem,
-      label: "売上修正",
-      icon: Edit,
-    },
-  ]
-
+export default function Sidebar() {
+  const pathname = usePathname()
   return (
-    <div className="w-64 bg-gray-900 text-white h-full fixed left-64 top-0 flex flex-col">
+    <div className="w-64 bg-gray-900 text-white h-screen fixed left-0 top-0 flex flex-col">
       <div className="p-6 border-b border-gray-700">
-        <h1 className="text-lg font-semibold">売上報告システム</h1>
+        <h1 className="text-lg font-semibold">TSAシステム</h1>
       </div>
-
-      <nav className="flex-1 p-4">
-        <div className="space-y-2">
-          {navigationItems.map((item) => {
-            const Icon = item.icon
-            return (
-              <Button
-                key={item.id}
-                variant={activeView === item.id ? "secondary" : "ghost"}
-                className={`w-full justify-start text-sm h-10 ${
-                  activeView === item.id ? "bg-gray-700 text-white" : "text-gray-300 hover:text-white hover:bg-gray-800"
-                }`}
-                onClick={() => onViewChange(item.id)}
-              >
-                <Icon className="mr-3 h-4 w-4" />
-                {item.label}
-              </Button>
-            )
-          })}
-        </div>
+      <nav className="flex-1 p-4 space-y-6 overflow-y-auto">
+        {sections.map((section) => (
+          <div key={section.title} className="space-y-2">
+            <h2 className="px-2 text-sm font-bold text-gray-300">{section.title}</h2>
+            {section.items.map((item) => {
+              const active = pathname === item.href
+              const Icon = item.icon
+              return (
+                <Link key={item.href} href={item.href} className="block">
+                  <Button
+                    variant={active ? "secondary" : "ghost"}
+                    className={`w-full justify-start text-sm h-10 ${
+                      active
+                        ? "bg-gray-700 text-white"
+                        : "text-gray-300 hover:text-white hover:bg-gray-800"
+                    }`}
+                  >
+                    <Icon className="mr-3 h-4 w-4" />
+                    {item.label}
+                  </Button>
+                </Link>
+              )
+            })}
+          </div>
+        ))}
       </nav>
-
-      <div className="p-4 border-t border-gray-700">
-        <p className="text-xs text-gray-400">会津ブランド館</p>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- restructure routing under `/sales` and `/web-sales`
- update sidebar with both module sections
- change header title dynamically
- redirect root page to `/sales/dashboard`
- add placeholder AI pages

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684cfaebc6188321a4eb982c9085f9a8