### PR TITLE
Sort products by series_code and product_code

### DIFF
--- a/components/web-sales-input-view.tsx
+++ b/components/web-sales-input-view.tsx
@@ -49,8 +49,9 @@ export default function WebSalesInputView() {
   const loadData = async (month: string = reportMonth) => {
     const { data: products } = await supabase
       .from("products")
-      .select("id, name, series, price")
-      .order("id")
+      .select('*')
+      .order('series_code', { ascending: true })
+      .order('product_code', { ascending: true })
     const { data: summary } = await supabase
       .from("web_sales_summary")
       .select("*")


### PR DESCRIPTION
## Summary
- adjust product fetch order so that `/web-sales/input` displays a stable product list

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1387ff688321b8f1abf75e7cc476