### PR TITLE
Fix login redirect and ensure product ordering

### DIFF
--- a/app/login/LoginButton.tsx
+++ b/app/login/LoginButton.tsx
@@ -4,7 +4,7 @@ export default function LoginButton() {
   return (
     <button
       className="rounded bg-blue-600 px-6 py-3 font-medium text-white hover:bg-blue-700"
-      onClick={() => signIn("google")}
+      onClick={() => signIn("google", { callbackUrl: "/sales/dashboard" })}
     >
       Googleでログイン
     </button>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,7 +6,7 @@ import LoginButton from "./LoginButton";
 export default async function LoginPage() {
   const session = await getServerSession(authOptions);
   if (session) {
-    redirect("/dashboard");
+    redirect("/sales/dashboard");
   }
 
   return (


### PR DESCRIPTION
## Summary
- redirect login page to `/sales/dashboard`
- include callbackUrl in sign in button
- confirm product listing query sorts by `series_code` then `product_code`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684d155b4ce08321837eb36733eca1fc