### PR TITLE
Fix report month storage and reload

### DIFF
--- a/components/web-sales-input-view.tsx
+++ b/components/web-sales-input-view.tsx
@@ -44,7 +44,11 @@ export default function WebSalesInputView() {
       row.mercari +
       row.base +
       row.qoo10
-    return { ...row, total_count: total, total_sales: total * row.price }
+    return {
+      ...row,
+      total_count: total,
+      total_sales: total * row.price,
+    }
   }
 
   const loadData = async (month: string = reportMonth) => {
@@ -58,7 +62,7 @@ export default function WebSalesInputView() {
     const { data: summary } = await supabase
       .from("web_sales_summary")
       .select("*")
-      .eq("report_month", month)
+      .eq("report_month", `${month}-01`)
 
     const map: Record<number, any> = {}
     ;(summary || []).forEach((s) => {
@@ -122,7 +126,7 @@ export default function WebSalesInputView() {
   const save = async () => {
     for (const row of rows) {
       const payload: WebSalesSummary = {
-        report_month: reportMonth,
+        report_month: `${reportMonth}-01`,
         product_id: row.id,
         amazon: row.amazon,
         rakuten: row.rakuten,
@@ -146,6 +150,7 @@ export default function WebSalesInputView() {
     }
     alert("保存しました")
     setRows((prev) => prev.map((r) => ({ ...r, editing: false })))
+    loadData(reportMonth)
   }
 
   const f = (n: number) => new Intl.NumberFormat("ja-JP").format(n)


### PR DESCRIPTION
## Summary
- keep editing state while recalculating rows
- query and save web sales summary rows using `YYYY-MM-01`
- refresh data after saving

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1e9f75b883218958e9cbb341cdad