### PR TITLE
Fix report month query

### DIFF
--- a/components/web-sales-input-view.tsx
+++ b/components/web-sales-input-view.tsx
@@ -62,7 +62,7 @@ export default function WebSalesInputView() {
     const { data: summary } = await supabase
       .from("web_sales_summary")
       .select("*")
-      .eq("report_month", `${month}-01`)
+      .eq("report_month", `${reportMonth}-01`)
 
     const map: Record<number, any> = {}
     ;(summary || []).forEach((s) => {


### PR DESCRIPTION
## Summary
- ensure report_month filter uses `reportMonth-01`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d223bf5788321989b5d4e02f12d69