### PR TITLE
Fix editing state persistence and month query

### DIFF
--- a/components/web-sales-input-view.tsx
+++ b/components/web-sales-input-view.tsx
@@ -48,6 +48,7 @@ export default function WebSalesInputView() {
       ...row,
       total_count: total,
       total_sales: total * row.price,
+      editing: row.editing ?? false,
     }
   }
 


### PR DESCRIPTION
## Summary
- preserve `editing` flag inside recalc so toggleEdit works for all rows
- ensure monthly queries use `${reportMonth}-01`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d26d639a08321bdc527d4d5b4d5be