### PR TITLE
Fix web sales input default values

### DIFF
--- a/components/web-sales-input-view.tsx
+++ b/components/web-sales-input-view.tsx
@@ -222,7 +222,7 @@ export default function WebSalesInputView() {
                     <td key={key} className="border px-2 py-1">
                       <Input
                         type="number"
-                        value={r[key]}
+                        defaultValue={r[key] ?? 0}
                         disabled={!r.editing}
                         onChange={(e) =>
                           handleChange(r.id, key, parseInt(e.target.value) || 0)


### PR DESCRIPTION
## Summary
- show existing counts in WebSalesInputView by default

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3f42b9bc8321be08c5e86bc49fb0