### PR TITLE
Update web sales RPC & add series_code to front

### DIFF
--- a/components/web-sales-input-view.tsx
+++ b/components/web-sales-input-view.tsx
@@ -12,6 +12,7 @@ type Row = {
   product_id: string;
   product_name: string;
   series_name: string | null;
+  series_code: number;
   price: number | null;
   amazon_count: number;
   rakuten_count: number;
@@ -45,6 +46,7 @@ export default function WebSalesInputView() {
           product_id: r.product_id,
           product_name: r.product_name,
           series_name: r.series_name,
+          series_code: r.series_code,
           price: r.price,
           amazon_count: r.amazon_count ?? 0,
           rakuten_count: r.rakuten_count ?? 0,
@@ -71,7 +73,7 @@ export default function WebSalesInputView() {
     id: string,
     field: keyof Omit<
       Row,
-      "id" | "product_id" | "product_name" | "series_name" | "price"
+      "id" | "product_id" | "product_name" | "series_name" | "series_code" | "price"
     >,
     val: number
   ) =>

--- a/scripts/create-web-sales-full-month-function.sql
+++ b/scripts/create-web-sales-full-month-function.sql
@@ -1,0 +1,38 @@
+create or replace function public.web_sales_full_month(target_month date)
+returns table (
+  id uuid,
+  product_id uuid,
+  product_name text,
+  series_name text,
+  series_code int4,
+  price numeric,
+  amazon_count int4,
+  rakuten_count int4,
+  yahoo_count int4,
+  mercari_count int4,
+  base_count int4,
+  qoo10_count int4
+)
+language sql stable
+as $$
+select
+  w.id,
+  p.id         as product_id,
+  p.name       as product_name,
+  p.series     as series_name,
+  p.series_code,
+  p.price,
+  coalesce(w.amazon_count ,0) as amazon_count ,
+  coalesce(w.rakuten_count,0) as rakuten_count,
+  coalesce(w.yahoo_count  ,0) as yahoo_count  ,
+  coalesce(w.mercari_count,0) as mercari_count,
+  coalesce(w.base_count   ,0) as base_count   ,
+  coalesce(w.qoo10_count  ,0) as qoo10_count
+from products p
+left join web_sales_summary w
+  on w.product_id   = p.id
+ and w.report_month = target_month
+order by p.series_code, p.name;
+$$;
+
+grant execute on function public.web_sales_full_month(date) to anon, authenticated;


### PR DESCRIPTION
## Summary
- create SQL script for web_sales_full_month function
- add `series_code` to Row type in `web-sales-input-view.tsx`
- map `series_code` from RPC response
- exclude `series_code` from update-able fields

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d69b5a9848321a68ea6fc1f5b638b