### PR TITLE
Fix sales report generation reset

### DIFF
--- a/components/GenerateReportButton.tsx
+++ b/components/GenerateReportButton.tsx
@@ -5,12 +5,16 @@ import { Button } from './ui/button'
 
 export default function GenerateReportButton() {
   const [loading, setLoading] = useState(false)
+  const [reportText, setReportText] = useState('')
 
   const handleClick = async () => {
+    // Always reset previous report before generating a new one
+    setReportText('')
     setLoading(true)
     try {
       const res = await fetch('/api/report', { method: 'POST' })
       const text = await res.text()
+      setReportText(text)
       await navigator.clipboard.writeText(text)
     } catch (e) {
       console.error(e)

--- a/sales-report-form.tsx
+++ b/sales-report-form.tsx
@@ -112,6 +112,9 @@ ${data.remarks ? `備考: ${data.remarks}` : ""}`
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsSubmitting(true)
+    // Reset existing report state before generating a new one
+    setIsSubmitted(false)
+    setReportData(null)
 
     try {
       const salesData: Omit<DailySalesReport, "id" | "created_at"> = {


### PR DESCRIPTION
## Summary
- reset report state before creating a new record
- ensure clipboard text is replaced when regenerating reports

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2295babc8321b8388dbbd4542f75