### PR TITLE
Remove use client directives

### DIFF
--- a/components/sales-edit-view.tsx
+++ b/components/sales-edit-view.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import type React from "react"
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
@@ -10,7 +8,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Calendar } from "@/components/ui/calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { CalendarIcon, CheckCircle } from "lucide-react"
-import { supabase, type DailySalesReport } from "../lib/supabase"
+import { supabase, type DailySalesReport } from "@/lib/supabase"
 import { formatDateJST } from "@/lib/utils"
 
 const salesChannels = [

--- a/components/web-sales-input-view.tsx
+++ b/components/web-sales-input-view.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 
@@ -41,6 +39,12 @@ const WebSalesInputView = () => {
   const [ym, setYm] = useState('2025-04');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  if (error) {
+    return (
+      <div className="p-4 rounded bg-red-100">読み込みエラー: {error}</div>
+    );
+  }
 
   const load = async (month: string) => {
     setLoading(true);
@@ -209,12 +213,7 @@ const WebSalesInputView = () => {
         </div>
       </div>
 
-      {/* エラー表示 */}
-      {error && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-3 py-2 rounded text-sm">
-          <strong>エラー:</strong> {error}
-        </div>
-      )}
+
 
       {/* ローディング表示 */}
       {loading && (


### PR DESCRIPTION
## Summary
- drop `use client` directives in web and sales edit views
- adjust error handling in WebSalesInputView
- use alias path to import supabase in SalesEditView

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e25cebea483218719a4bcee78b953