### PR TITLE
Fix AI dashboard monthly analysis

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -2,7 +2,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import OpenAI from 'openai';
-import { formatDateJST } from '@/lib/utils';
 
 const OPENAI_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
 
@@ -10,8 +9,11 @@ export async function POST(req: Request) {
   try {
     // ------- input -------
     const body = await req.json().catch(() => ({}));
-    const date = '2025-06-13'; // 固定: データがある最新日
-    const month = date.slice(0, 7); // "2025-06"
+    // クライアントから日付(YYYY-MM-DD)が送られてくる想定。無ければ今日の日付を使用
+    const date = typeof body.date === 'string'
+      ? body.date
+      : new Date().toISOString().slice(0, 10);
+    const month = date.slice(0, 7); // 例: "2025-06"
 
     // ------- env -------
     const url  = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -21,11 +23,16 @@ export async function POST(req: Request) {
 
     // ------- db -------
     const supabase = createClient(url, key);
+    const dateObj = new Date(date);
+    const lastDay = new Date(dateObj.getFullYear(), dateObj.getMonth() + 1, 0)
+      .toISOString()
+      .slice(0, 10);
+
     const { data: sales, error } = await supabase
       .from('daily_sales_report')
       .select('*')
       .gte('date', `${month}-01`)
-      .lte('date', date);
+      .lte('date', lastDay);
 
     if (error) throw new Error('select_failed: ' + error.message);
 
@@ -52,7 +59,11 @@ export async function POST(req: Request) {
       .from('ai_reports')
       .upsert({ month, content: summary }, { onConflict: 'month' });
 
-    return NextResponse.json({ ok: true, result: summary });
+    return NextResponse.json({
+      ok: true,
+      result: summary,
+      meta: { month, dataPoints: sales.length },
+    });
   } catch (e: any) {
     console.error('analyze_error', e);
     return NextResponse.json({ ok: false, error: e.message });


### PR DESCRIPTION
## Summary
- allow `/api/analyze` to use provided date rather than a fixed month
- compute month range dynamically and return metadata

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f803f5d80832181cd210d3b222446