### PR TITLE
feat(auth): unify Supabase client via singleton (multiTab:false) & remove direct createBrowserClient

### DIFF
--- a/app/finance/general-ledger-detail/page.tsx
+++ b/app/finance/general-ledger-detail/page.tsx
@@ -1,8 +1,8 @@
 // /app/finance/general-ledger-detail/page.tsx ver.1
 'use client';
 
-import { useState, useEffect } from 'react';
-import { createBrowserClient } from '@supabase/ssr';
+import { useState, useEffect, useMemo } from 'react';
+import getSupabase from '@/lib/supabaseClient';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { Search, MessageSquare, FileText, TrendingUp, Filter, Send, Loader2 } from 'lucide-react';
@@ -30,9 +30,9 @@ export default function GeneralLedgerDetailPage() {
   const [aiLoading, setAiLoading] = useState(false);
   const [queryHistory, setQueryHistory] = useState<Array<{question: string, response: string}>>([]);
 
-  const supabase = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  const supabase = useMemo(
+    () => (typeof window !== 'undefined' ? getSupabase() : null),
+    []
   );
 
   const itemsPerPage = 50;
@@ -77,6 +77,7 @@ export default function GeneralLedgerDetailPage() {
 
   // 勘定科目マスタ読み込み
   const loadAccountMaster = async () => {
+    if (!supabase) return;
     const { data, error } = await supabase
       .from('account_master')
       .select('account_code, account_name')
@@ -89,8 +90,9 @@ export default function GeneralLedgerDetailPage() {
 
   // 取引データ読み込み
   const loadTransactions = async () => {
+    if (!supabase) return;
     setDataLoading(true);
-    
+
     let query = supabase
       .from('general_ledger')
       .select(`

--- a/app/finance/general-ledger/page.tsx
+++ b/app/finance/general-ledger/page.tsx
@@ -5,8 +5,8 @@
 
 'use client';
 
-import { useState, useEffect } from 'react';
-import { createBrowserClient } from '@supabase/ssr';
+import { useState, useEffect, useMemo } from 'react';
+import getSupabase from '@/lib/supabaseClient';
 import { Database } from '@/types/supabase';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -74,9 +74,9 @@ export default function GeneralLedgerPage() {
 
   const router = useRouter();
 
-  const supabase = createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  const supabase = useMemo(
+    () => (typeof window !== 'undefined' ? getSupabase() : null),
+    []
   );
 
   const getFiscalYear = (dateStr: string): number => {
@@ -98,6 +98,7 @@ export default function GeneralLedgerPage() {
   };
 
   const fetchMonthlyData = async () => {
+    if (!supabase) return;
     try {
       setLoading(true);
 
@@ -245,6 +246,7 @@ export default function GeneralLedgerPage() {
   };
 
   const handleDelete = async (yyyymm: string) => {
+    if (!supabase) return;
     if (!confirm(`${yyyymm}のデータを削除してもよろしいですか？`)) return;
 
     const year = parseInt(yyyymm.substring(0, 4));

--- a/app/wholesale/dashboard/page.tsx
+++ b/app/wholesale/dashboard/page.tsx
@@ -14,12 +14,7 @@ import OEMArea from '@/components/wholesale/oem-area';
 import PriceHistoryControls from '@/components/wholesale/price-history-controls';
 import SalesDataTable from '@/components/wholesale/sales-data-table';
 import ProductStatistics from '@/components/wholesale/product-statistics';
-import { createClient } from '@supabase/supabase-js';
-
-// Supabaseクライアントの初期化
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+import getSupabase from '@/lib/supabaseClient';
 
 // インターフェース定義
 interface Product {
@@ -172,10 +167,11 @@ function WholesaleDashboardContent() {
  }, [selectedYear, selectedMonth, mounted]);
 
  // 価格履歴関連の関数
- const fetchPriceChangeDates = async () => {
-   try {
-     const { data, error } = await supabase
-       .from('wholesale_product_price_history')
+const fetchPriceChangeDates = async () => {
+  try {
+    const supabase = getSupabase();
+    const { data, error } = await supabase
+      .from('wholesale_product_price_history')
        .select('valid_from, product_id')
        .order('valid_from', { ascending: false });
      
@@ -203,12 +199,13 @@ function WholesaleDashboardContent() {
    }
  };
 
- const showPriceAtDate = async (date: string) => {
-   setLoadingHistorical(true);
-   setSelectedHistoryDate(date);
-   try {
-     const { data: historicalData, error } = await supabase.rpc(
-       'calculate_wholesale_sales_with_historical_prices',
+const showPriceAtDate = async (date: string) => {
+  setLoadingHistorical(true);
+  setSelectedHistoryDate(date);
+  try {
+    const supabase = getSupabase();
+    const { data: historicalData, error } = await supabase.rpc(
+      'calculate_wholesale_sales_with_historical_prices',
        { 
          p_month: `${selectedYear}-${selectedMonth}`,
          p_target_date: new Date(date + 'T00:00:00Z').toISOString()
@@ -227,13 +224,14 @@ function WholesaleDashboardContent() {
    }
  };
 
- const fetchHistoricalPrices = async () => {
-   setLoadingHistorical(true);
-   try {
-     const { data: historicalData, error } = await supabase.rpc(
-       'calculate_wholesale_sales_with_historical_prices',
-       { p_month: `${selectedYear}-${selectedMonth}` }
-     );
+const fetchHistoricalPrices = async () => {
+  setLoadingHistorical(true);
+  try {
+    const supabase = getSupabase();
+    const { data: historicalData, error } = await supabase.rpc(
+      'calculate_wholesale_sales_with_historical_prices',
+      { p_month: `${selectedYear}-${selectedMonth}` }
+    );
      
      if (error) throw error;
      

--- a/app/wholesale/price-history/page.tsx
+++ b/app/wholesale/price-history/page.tsx
@@ -4,14 +4,9 @@
 import React, { useState, useEffect } from "react"
 import { useRouter } from 'next/navigation'
 import { X, Trash2, Calendar, Package, ChevronLeft, TrendingUp } from "lucide-react"
-import { createClient } from '@supabase/supabase-js'
+import getSupabase from '@/lib/supabaseClient'
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-
-// Supabaseクライアントの初期化
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 interface DateHistory {
   change_date: string
@@ -40,6 +35,7 @@ export default function WholesalePriceHistory() {
   const fetchDateHistories = async () => {
     setLoading(true)
     try {
+      const supabase = getSupabase()
       // 価格変更履歴を日付でグループ化して取得
       const { data: historyData, error: historyError } = await supabase
         .from('wholesale_product_price_history')
@@ -116,6 +112,7 @@ export default function WholesalePriceHistory() {
 
     setDeleting(date)
     try {
+      const supabase = getSupabase()
       // 複数の履歴を一括削除
       const { error } = await supabase
         .from('wholesale_product_price_history')

--- a/components/finance/BalanceSheet.tsx
+++ b/components/finance/BalanceSheet.tsx
@@ -1,7 +1,7 @@
 // /components/finance/BalanceSheet.tsx ver.2
 "use client";
 import React from "react";
-import { createBrowserClient } from "@supabase/ssr";
+import getSupabase from "@/lib/supabaseClient";
 
 // 通貨表記
 const jpy = (v: number) => (v < 0 ? `△¥${Math.abs(v).toLocaleString()}` : `¥${v.toLocaleString()}`);
@@ -12,13 +12,9 @@ const toNum = (v: any) =>
 const normMonth = (m: string) => (m?.length === 7 ? `${m}-01` : m);
 
 export default function BalanceSheet({ month }: { month: string }) {
-  // Supabase クライアントをブラウザ側で生成（方針：createBrowserClient を直接使用）
+  // Supabase クライアントをシングルトンから取得（ビルド時は null）
   const supabase = React.useMemo(
-    () =>
-      createBrowserClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-      ),
+    () => (typeof window !== "undefined" ? getSupabase() : null),
     []
   );
 
@@ -30,6 +26,7 @@ export default function BalanceSheet({ month }: { month: string }) {
   const [loading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
+    if (!supabase) return;
     let mounted = true;
     const m = normMonth(month);
     (async () => {

--- a/components/finance/CashFlow.tsx
+++ b/components/finance/CashFlow.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { createBrowserClient } from '@supabase/ssr';
+import getSupabase from '@/lib/supabaseClient';
 import { TrendingUp, TrendingDown, DollarSign, Loader2 } from 'lucide-react';
 
 /**
@@ -167,10 +167,7 @@ export function CashFlow({ month, includingClosing }: CashFlowProps) {
       }
 
       try {
-        const supabase = createBrowserClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-        );
+        const supabase = getSupabase();
 
         // 選択月と前月
         const targetMonth = month; // YYYY-MM

--- a/components/finance/DetailSearch.tsx
+++ b/components/finance/DetailSearch.tsx
@@ -1,8 +1,8 @@
 // /components/finance/DetailSearch.tsx ver.1
 'use client';
 
-import { useState, useEffect } from 'react';
-import { createBrowserClient } from '@supabase/ssr';
+import { useState, useEffect, useMemo } from 'react';
+import getSupabase from '@/lib/supabaseClient';
 import { Search } from 'lucide-react';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
@@ -21,10 +21,10 @@ export function DetailSearch({ selectedMonth }: DetailSearchProps) {
   const [totalPages, setTotalPages] = useState(1);
   const [dataLoading, setDataLoading] = useState(false);
 
-  const supabase = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+    const supabase = useMemo(
+      () => (typeof window !== 'undefined' ? getSupabase() : null),
+      []
+    );
 
   const itemsPerPage = 50;
 
@@ -34,6 +34,7 @@ export function DetailSearch({ selectedMonth }: DetailSearchProps) {
   }, [selectedMonth, selectedAccount, searchTerm, currentPage]);
 
   const loadAccountMaster = async () => {
+    if (!supabase) return;
     const { data } = await supabase
       .from('account_master')
       .select('account_code, account_name')
@@ -45,8 +46,9 @@ export function DetailSearch({ selectedMonth }: DetailSearchProps) {
   };
 
   const loadTransactions = async () => {
+    if (!supabase) return;
     setDataLoading(true);
-    
+
     let query = supabase
       .from('general_ledger')
       .select(`

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -5,28 +5,25 @@ import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 declare global {
-  // HMR や複数 import でも同一インスタンス共有
+  // HMR/重複importでも同一インスタンス共有
   // eslint-disable-next-line no-var
   var __tsai_supabase__: SupabaseClient | undefined;
 }
 
+/** ブラウザ専用 Supabase クライアント（シングルトン） */
 export const getSupabase = (): SupabaseClient => {
-  if (typeof window === "undefined") {
-    throw new Error("getSupabase() is browser-only.");
-  }
+  if (typeof window === "undefined") throw new Error("getSupabase() is browser-only.");
   if (!globalThis.__tsai_supabase__) {
     const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
     const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
     globalThis.__tsai_supabase__ = createBrowserClient(url, anon, {
       auth: {
-        // 衝突しない専用キーを明示
         storageKey: "tsai-auth",
         flowType: "pkce",
         persistSession: true,
         autoRefreshToken: true,
         detectSessionInUrl: true,
-        // ★これで Broadcast/Storage の多重監視を止める
-        //   （同一タブ内の複数クライアントが居ても衝突しなくなる）
+        // 衝突源を遮断
         multiTab: false,
       },
     }) as unknown as SupabaseClient;


### PR DESCRIPTION
## Summary
- centralize Supabase access with browser-only singleton and multiTab disabled
- swap direct Supabase client creation for `getSupabase()` across finance and wholesale pages
- guard client-side hooks to avoid server build execution

## Testing
- `npm run build`

### Post-merge step
Please clear browser storage once:
```js
Object.keys(localStorage)
  .filter(k => k.includes('supabase') || k.startsWith('sb-') || k.includes('tsai-auth'))
  .forEach(k => localStorage.removeItem(k));
sessionStorage.clear();
// then hard-reload with Ctrl+Shift+R
```


------
https://chatgpt.com/codex/tasks/task_e_68a3e197d6cc8321a965ac0563cf80fd