### PR TITLE
feat(ui): add DatePickerClient and SalesCharts placeholders for dashboard

### DIFF
--- a/components/common/DatePickerClient.tsx
+++ b/components/common/DatePickerClient.tsx
@@ -1,0 +1,28 @@
+// /components/common/DatePickerClient.tsx ver.1 (2025-08-19 JST)
+'use client';
+import { useMemo } from 'react';
+
+type Props = { value: Date; onChange: (d: Date) => void; className?: string };
+
+function fmt(d: Date) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export default function DatePickerClient({ value, onChange, className }: Props) {
+  const v = useMemo(() => fmt(value), [value]);
+  return (
+    <input
+      type="date"
+      className={className}
+      value={v}
+      onChange={(e) => {
+        const [y, m, d] = e.target.value.split('-').map(Number);
+        if (!isNaN(y) && !isNaN(m) && !isNaN(d)) onChange(new Date(y, m - 1, d));
+      }}
+    />
+  );
+}
+

--- a/components/sales/SalesCharts.tsx
+++ b/components/sales/SalesCharts.tsx
@@ -1,0 +1,14 @@
+// /components/sales/SalesCharts.tsx ver.1 (2025-08-19 JST)
+'use client';
+type Props = { date: Date };
+export default function SalesCharts({ date }: Props) {
+  // プレースホルダー：まずビルドを通す。後で本実装を移植。
+  return (
+    <div className="w-full h-[360px] rounded-xl border border-dashed p-4">
+      <div className="text-sm opacity-70">
+        Charts placeholder — {date.toISOString().slice(0, 10)}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add DatePickerClient client-side date input component
- add SalesCharts placeholder component for dashboard

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a43618592483219af93623e2eafe9f