### PR TITLE
fix(brand-store-analysis): drop revalidate/fetchCache on client page; keep dynamic=force-dynamic

### DIFF
--- a/app/brand-store-analysis/page.tsx
+++ b/app/brand-store-analysis/page.tsx
@@ -1,6 +1,9 @@
 // /app/brand-store-analysis/page.tsx ver.9（売上修正履歴機能追加版）
 "use client"
 
+// 動的ページとして扱い、SSGしない（これだけでOK）
+export const dynamic = 'force-dynamic';
+
 import { useState, useEffect, Suspense } from 'react'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import { Button } from '@/components/ui/button'


### PR DESCRIPTION
## Summary
- avoid SSG for brand-store analysis page with `dynamic='force-dynamic'`

## Testing
- `npm run build` *(fails: Error: supabaseUrl is required; Failed to collect page data for /api/finance/ai-query)*

------
https://chatgpt.com/codex/tasks/task_e_68a546389e688321b8c3e9f4598b0df8