### PR TITLE
refactor: client-only sales dashboard

### DIFF
--- a/app/brand-store-analysis/page.tsx
+++ b/app/brand-store-analysis/page.tsx
@@ -5,7 +5,7 @@
 export const dynamic = 'force-dynamic';
 
 import { useState, useEffect, Suspense } from 'react'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -35,7 +35,7 @@ function BrandStoreAnalysisContent() {
   const [chartData, setChartData] = useState<any[]>([])
   const [adjustmentAmount, setAdjustmentAmount] = useState<number>(0)
   const [loading, setLoading] = useState(false)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // URLパラメータから年月を読み取る
   useEffect(() => {

--- a/app/food-store-analysis/page.tsx
+++ b/app/food-store-analysis/page.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect, Suspense } from "react"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import FoodStoreCsvImportModal from "@/components/food-store/FoodStoreCsvImportModal"
 import CategoryManagementModal from "@/components/food-store/CategoryManagementModal"
 import ProductCategoryMappingModal from "@/components/food-store/ProductCategoryMappingModal"
@@ -29,7 +29,7 @@ function FoodStoreAnalysisContent() {
  const [data, setData] = useState<any>(null)
  const [chartData, setChartData] = useState<any[]>([])
  const [loading, setLoading] = useState(false)
- const supabase = createClientComponentClient()
+ const supabase = getSupabaseBrowserClient()
 
  // URLパラメータから年月を読み取る
  useEffect(() => {

--- a/app/sales/dashboard/page.tsx
+++ b/app/sales/dashboard/page.tsx
@@ -1,17 +1,11 @@
-// app/sales/dashboard/page.tsx (修正後)
-
-// このページを動的にレンダリングするようにNext.jsに指示する
 export const dynamic = 'force-dynamic';
+export const revalidate = false;
+export const fetchCache = 'force-no-store';
+import dynamic from 'next/dynamic';
 
-// 'use client' はこのファイルでは不要です。
-// 子コンポーネントのDashboardViewがクライアントコンポーネントであれば問題ありません。
+const DashboardClient = dynamic(() => import('@/components/sales/DashboardClient'), { ssr: false });
 
-import DashboardView from '@/components/dashboard-view';
-
-export default function SalesDashboardPage() {
-    return (
-        <div className="p-4 md:p-6 lg:p-8">
-            <DashboardView />
-        </div>
-    )
+export default function Page() {
+  return <DashboardClient />;
 }
+

--- a/components/ai-dashboard-section.tsx
+++ b/components/ai-dashboard-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser';
 import { toast } from "sonner";
 
 export default function AiDashboardSection() {
@@ -10,7 +10,7 @@ export default function AiDashboardSection() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isAnalyzing, setIsAnalyzing] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const supabase = createClientComponentClient();
+  const supabase = getSupabaseBrowserClient();
 
   // "YYYY-MM" 形式を "YYYY年M月" 形式に変換
   const formatMonth = (month: string | null): string => {

--- a/components/brand-store/MasterDataModal.tsx
+++ b/components/brand-store/MasterDataModal.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { Upload, FileText, AlertCircle, Search, Package, Tag, Eye, FileUp } from "lucide-react"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { formatCurrency } from "@/lib/utils"
 
 interface Props {
@@ -25,7 +25,7 @@ export function MasterDataModal({ isOpen, onClose }: Props) {
   const [productSearch, setProductSearch] = useState("")
   const [viewMode, setViewMode] = useState<'view' | 'import'>('view')
   const [viewType, setViewType] = useState<'categories' | 'products'>('categories')
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // マスターデータを取得
   const fetchMasterData = async () => {

--- a/components/brand-store/SalesAdjustmentHistoryModal.tsx
+++ b/components/brand-store/SalesAdjustmentHistoryModal.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -53,7 +53,7 @@ export function SalesAdjustmentHistoryModal({
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editAmount, setEditAmount] = useState<string>('')
   const [editReason, setEditReason] = useState<string>('')
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // データ取得
   const fetchAdjustments = async () => {

--- a/components/brand-store/SalesAdjustmentModal.tsx
+++ b/components/brand-store/SalesAdjustmentModal.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useState } from 'react'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -36,7 +36,7 @@ export function SalesAdjustmentModal({
   const [adjustmentAmount, setAdjustmentAmount] = useState<string>('')
   const [adjustmentReason, setAdjustmentReason] = useState<string>('')
   const [isLoading, setIsLoading] = useState(false)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   const handleSubmit = async () => {
     if (!adjustmentAmount || adjustmentAmount === '0') {

--- a/components/common/Hydrated.tsx
+++ b/components/common/Hydrated.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { useEffect, useState, type ReactNode } from 'react';
+
+export default function Hydrated({ children }: { children: ReactNode }) {
+  const [ready, setReady] = useState(false);
+  useEffect(() => setReady(true), []);
+  if (!ready) return null;
+  return <>{children}</>;
+}
+

--- a/components/food-store/CategoryManagementModal.tsx
+++ b/components/food-store/CategoryManagementModal.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Plus, Edit2, Trash2, GripVertical } from "lucide-react"
 import {
   Table,
@@ -26,7 +26,7 @@ function CategoryManagementModal({ isOpen, onClose }: CategoryManagementModalPro
   const [newCategoryName, setNewCategoryName] = useState("")
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editingName, setEditingName] = useState("")
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   useEffect(() => {
     if (isOpen) {

--- a/components/food-store/FoodStoreCsvImportModal.tsx
+++ b/components/food-store/FoodStoreCsvImportModal.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import Papa from 'papaparse'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 
 interface FoodStoreCsvImportModalProps {
   isOpen?: boolean
@@ -30,7 +30,7 @@ export default function FoodStoreCsvImportModal({
   const [isImporting, setIsImporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // モーダルが開いた時に年月を自動セット
   useEffect(() => {

--- a/components/food-store/ProductCategoryMappingModal.tsx
+++ b/components/food-store/ProductCategoryMappingModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 
 interface ProductCategoryMappingModalProps {
   isOpen: boolean
@@ -36,7 +36,7 @@ function ProductCategoryMappingModal({
   const [grossProfitRates, setGrossProfitRates] = useState<{[key: number]: string}>({})
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   useEffect(() => {
     if (isOpen) {

--- a/components/sales/DashboardClient.tsx
+++ b/components/sales/DashboardClient.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useEffect, useState, Suspense } from 'react';
+import dynamic from 'next/dynamic';
+import Hydrated from '@/components/common/Hydrated';
+
+const SalesCharts = dynamic(() => import('@/components/sales/SalesCharts'), { ssr: false });
+const DatePickerClient = dynamic(() => import('@/components/common/DatePickerClient'), { ssr: false });
+
+export default function DashboardClient() {
+  return (
+    <Suspense fallback={null}>
+      <Hydrated>
+        <Inner />
+      </Hydrated>
+    </Suspense>
+  );
+}
+
+function Inner() {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  useEffect(() => { setSelectedDate(new Date()); }, []);
+  if (!selectedDate) return null;
+
+  return (
+    <div className="p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">統合売上ダッシュボード</h1>
+        <DatePickerClient value={selectedDate} onChange={setSelectedDate} />
+      </div>
+      <div className="mt-6">
+        <SalesCharts date={selectedDate} />
+      </div>
+    </div>
+  );
+}
+

--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,12 +1,15 @@
 'use client';
-// ver.1 (2025-08-19 JST) - singleton supabase client
+// ver.2 (2025-08-20 JST) - singleton supabase client
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 const STORAGE_KEY = 'sb-tsai-sales-db';
 let _sb: SupabaseClient | undefined;
-export default function getSupabase() {
+
+export function getSupabaseBrowserClient() {
   if (_sb) return _sb;
   _sb = createClient(url, anon, { auth: { persistSession: true, storageKey: STORAGE_KEY } });
   return _sb;
 }
+
+export default getSupabaseBrowserClient;


### PR DESCRIPTION
## Summary
- client-only dashboard page delegates to new DashboardClient component
- provide Hydrated wrapper to delay rendering until after hydration
- replace createClientComponentClient with singleton getSupabaseBrowserClient to avoid GoTrue warnings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive prompt for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a54b1552448321adca555abb7c6cde