### PR TITLE
fix: hydrate-safe date rendering and singleton Supabase client

### DIFF
--- a/app/brand-store-analysis/page.tsx
+++ b/app/brand-store-analysis/page.tsx
@@ -5,7 +5,7 @@
 export const dynamic = 'force-dynamic';
 
 import { useState, useEffect, Suspense } from 'react'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -35,7 +35,7 @@ function BrandStoreAnalysisContent() {
   const [chartData, setChartData] = useState<any[]>([])
   const [adjustmentAmount, setAdjustmentAmount] = useState<number>(0)
   const [loading, setLoading] = useState(false)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // URLパラメータから年月を読み取る
   useEffect(() => {

--- a/app/finance/general-ledger-detail/ClientGLDetail.tsx
+++ b/app/finance/general-ledger-detail/ClientGLDetail.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import getSupabase from '@/lib/supabase/browser'; // ver.2 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'; // ver.2 (2025-08-19 JST) - browser singleton client
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { Search, MessageSquare, FileText, TrendingUp, Filter, Send, Loader2 } from 'lucide-react';
@@ -31,7 +31,7 @@ export default function ClientGLDetail() {
   const [queryHistory, setQueryHistory] = useState<Array<{question: string, response: string}>>([]);
 
   const supabase = useMemo(
-    () => (typeof window !== 'undefined' ? getSupabase() : null),
+    () => (typeof window !== 'undefined' ? getSupabaseBrowserClient() : null),
     []
   );
 

--- a/app/finance/general-ledger/ClientGL.tsx
+++ b/app/finance/general-ledger/ClientGL.tsx
@@ -3,7 +3,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import getSupabase from "@/lib/supabase/browser"; // ver.2 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from "@/lib/supabase/browser"; // ver.2 (2025-08-19 JST) - browser singleton client
 
 // ===== shadcn/ui =====
 import { Button } from "@/components/ui/button";
@@ -150,7 +150,7 @@ const getFiscalYearLabel = (year: number) => {
 
 // ====== Component ======
 export default function ClientGL() {
-  const supabase = useMemo(() => getSupabase(), []);
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
   const router = useRouter();
 
   const [monthlyData, setMonthlyData] = useState<MonthlyData[]>([]);

--- a/app/food-store-analysis/page.tsx
+++ b/app/food-store-analysis/page.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect, Suspense } from "react"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import FoodStoreCsvImportModal from "@/components/food-store/FoodStoreCsvImportModal"
 import CategoryManagementModal from "@/components/food-store/CategoryManagementModal"
 import ProductCategoryMappingModal from "@/components/food-store/ProductCategoryMappingModal"
@@ -29,7 +29,7 @@ function FoodStoreAnalysisContent() {
  const [data, setData] = useState<any>(null)
  const [chartData, setChartData] = useState<any[]>([])
  const [loading, setLoading] = useState(false)
- const supabase = createClientComponentClient()
+ const supabase = getSupabaseBrowserClient()
 
  // URLパラメータから年月を読み取る
  useEffect(() => {

--- a/app/wholesale/dashboard/page.tsx
+++ b/app/wholesale/dashboard/page.tsx
@@ -14,7 +14,7 @@ import OEMArea from '@/components/wholesale/oem-area';
 import PriceHistoryControls from '@/components/wholesale/price-history-controls';
 import SalesDataTable from '@/components/wholesale/sales-data-table';
 import ProductStatistics from '@/components/wholesale/product-statistics';
-import getSupabase from '@/lib/supabase/browser'; // ver.40 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'; // ver.40 (2025-08-19 JST) - browser singleton client
 
 // インターフェース定義
 interface Product {
@@ -169,7 +169,7 @@ function WholesaleDashboardContent() {
  // 価格履歴関連の関数
 const fetchPriceChangeDates = async () => {
   try {
-    const supabase = getSupabase();
+    const supabase = getSupabaseBrowserClient();
     const { data, error } = await supabase
       .from('wholesale_product_price_history')
        .select('valid_from, product_id')
@@ -203,7 +203,7 @@ const showPriceAtDate = async (date: string) => {
   setLoadingHistorical(true);
   setSelectedHistoryDate(date);
   try {
-    const supabase = getSupabase();
+    const supabase = getSupabaseBrowserClient();
     const { data: historicalData, error } = await supabase.rpc(
       'calculate_wholesale_sales_with_historical_prices',
        { 
@@ -227,7 +227,7 @@ const showPriceAtDate = async (date: string) => {
 const fetchHistoricalPrices = async () => {
   setLoadingHistorical(true);
   try {
-    const supabase = getSupabase();
+    const supabase = getSupabaseBrowserClient();
     const { data: historicalData, error } = await supabase.rpc(
       'calculate_wholesale_sales_with_historical_prices',
       { p_month: `${selectedYear}-${selectedMonth}` }

--- a/app/wholesale/price-history/page.tsx
+++ b/app/wholesale/price-history/page.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect } from "react"
 import { useRouter } from 'next/navigation'
 import { X, Trash2, Calendar, Package, ChevronLeft, TrendingUp } from "lucide-react"
-import getSupabase from '@/lib/supabase/browser' // ver.3 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser' // ver.3 (2025-08-19 JST) - browser singleton client
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 
@@ -35,7 +35,7 @@ export default function WholesalePriceHistory() {
   const fetchDateHistories = async () => {
     setLoading(true)
     try {
-      const supabase = getSupabase()
+      const supabase = getSupabaseBrowserClient()
       // 価格変更履歴を日付でグループ化して取得
       const { data: historyData, error: historyError } = await supabase
         .from('wholesale_product_price_history')
@@ -112,7 +112,7 @@ export default function WholesalePriceHistory() {
 
     setDeleting(date)
     try {
-      const supabase = getSupabase()
+      const supabase = getSupabaseBrowserClient()
       // 複数の履歴を一括削除
       const { error } = await supabase
         .from('wholesale_product_price_history')

--- a/components/ai-dashboard-section.tsx
+++ b/components/ai-dashboard-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser';
 import { toast } from "sonner";
 
 export default function AiDashboardSection() {
@@ -10,7 +10,7 @@ export default function AiDashboardSection() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isAnalyzing, setIsAnalyzing] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const supabase = createClientComponentClient();
+  const supabase = getSupabaseBrowserClient();
 
   // "YYYY-MM" 形式を "YYYY年M月" 形式に変換
   const formatMonth = (month: string | null): string => {

--- a/components/brand-store/MasterDataModal.tsx
+++ b/components/brand-store/MasterDataModal.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { Upload, FileText, AlertCircle, Search, Package, Tag, Eye, FileUp } from "lucide-react"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { formatCurrency } from "@/lib/utils"
 
 interface Props {
@@ -25,7 +25,7 @@ export function MasterDataModal({ isOpen, onClose }: Props) {
   const [productSearch, setProductSearch] = useState("")
   const [viewMode, setViewMode] = useState<'view' | 'import'>('view')
   const [viewType, setViewType] = useState<'categories' | 'products'>('categories')
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // マスターデータを取得
   const fetchMasterData = async () => {

--- a/components/brand-store/SalesAdjustmentHistoryModal.tsx
+++ b/components/brand-store/SalesAdjustmentHistoryModal.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -53,7 +53,7 @@ export function SalesAdjustmentHistoryModal({
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editAmount, setEditAmount] = useState<string>('')
   const [editReason, setEditReason] = useState<string>('')
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // データ取得
   const fetchAdjustments = async () => {

--- a/components/brand-store/SalesAdjustmentModal.tsx
+++ b/components/brand-store/SalesAdjustmentModal.tsx
@@ -2,7 +2,7 @@
 'use client'
 
 import { useState } from 'react'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -36,7 +36,7 @@ export function SalesAdjustmentModal({
   const [adjustmentAmount, setAdjustmentAmount] = useState<string>('')
   const [adjustmentReason, setAdjustmentReason] = useState<string>('')
   const [isLoading, setIsLoading] = useState(false)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   const handleSubmit = async () => {
     if (!adjustmentAmount || adjustmentAmount === '0') {

--- a/components/common/ClientDate.tsx
+++ b/components/common/ClientDate.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+type Props = { timeZone?: string };
+export default function ClientDate({ timeZone = 'Asia/Tokyo' }: Props) {
+  const [text, setText] = useState('');
+  useEffect(() => {
+    const d = new Date();
+    const y = new Intl.DateTimeFormat('ja-JP', { timeZone, year: 'numeric' }).format(d);
+    const m = new Intl.DateTimeFormat('ja-JP', { timeZone, month: '2-digit' }).format(d);
+    const day = new Intl.DateTimeFormat('ja-JP', { timeZone, day: '2-digit' }).format(d);
+    setText(`${y}.${m}.${day}`);
+  }, [timeZone]);
+  return <span>{text}</span>;
+}
+

--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -7,6 +7,7 @@ import { useSession } from "next-auth/react";
 import dynamic from 'next/dynamic';
 
 import DashboardHeader from './dashboard-header';
+import ClientDate from '@/components/common/ClientDate';
 import DashboardStats from './dashboard-stats';
 import DailySalesCrudForm from './daily-sales-crud-form';
 import AiDashboardSection from './ai-dashboard-section';
@@ -109,6 +110,7 @@ export default function DashboardView() {
 
     return (
         <div className="p-4 md:p-6 lg:p-8 bg-slate-50 min-h-screen font-sans">
+            <div className="text-right text-sm text-slate-600"><ClientDate /></div>
             <DashboardHeader selectedDate={selectedDate} onDateChange={setSelectedDate} />
             
             <main className="mt-6 space-y-8">

--- a/components/finance/BalanceSheet.tsx
+++ b/components/finance/BalanceSheet.tsx
@@ -1,7 +1,7 @@
 // ver.4 (2025-08-19 JST) - use RPC bs_totals
 "use client";
 import React from "react";
-import getSupabase from "@/lib/supabase/browser"; // ver.4 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from "@/lib/supabase/browser"; // ver.4 (2025-08-19 JST) - browser singleton client
 
 // 通貨表記
 const jpy = (v: number) => (v < 0 ? `△¥${Math.abs(v).toLocaleString()}` : `¥${v.toLocaleString()}`);
@@ -14,7 +14,7 @@ const normMonth = (m: string) => (m?.length === 7 ? `${m}-01` : m);
 type BsRow = { side: 'assets' | 'liabilities' | 'equity'; total: number };
 // ver.4 (2025-08-19 JST) - use RPC bs_totals
 async function fetchBsTotals(month?: string): Promise<BsRow[]> {
-  const supabase = (typeof window === 'undefined') ? null : (await import('@/lib/supabase/browser')).default();
+  const supabase = (typeof window === 'undefined') ? null : (await import('@/lib/supabase/browser')).getSupabaseBrowserClient();
   if (!supabase) return [];
   if (month) {
     const { data, error } = await supabase.rpc('bs_totals', { target_month: month });
@@ -30,7 +30,7 @@ async function fetchBsTotals(month?: string): Promise<BsRow[]> {
 function BalanceSheet({ month }: { month: string }) {
   // Supabase クライアントをシングルトンから取得（ビルド時は null）
   const supabase = React.useMemo(
-    () => (typeof window !== "undefined" ? getSupabase() : null),
+    () => (typeof window !== "undefined" ? getSupabaseBrowserClient() : null),
     []
   );
 

--- a/components/finance/CashFlow.tsx
+++ b/components/finance/CashFlow.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import getSupabase from '@/lib/supabase/browser'; // ver.7 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'; // ver.7 (2025-08-19 JST) - browser singleton client
 import { TrendingUp, TrendingDown, DollarSign, Loader2 } from 'lucide-react';
 
 /**
@@ -167,7 +167,7 @@ export function CashFlow({ month, includingClosing }: CashFlowProps) {
       }
 
       try {
-        const supabase = getSupabase();
+        const supabase = getSupabaseBrowserClient();
 
         // 選択月と前月
         const targetMonth = month; // YYYY-MM

--- a/components/finance/DetailSearch.tsx
+++ b/components/finance/DetailSearch.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import getSupabase from '@/lib/supabase/browser'; // ver.2 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'; // ver.2 (2025-08-19 JST) - browser singleton client
 import { Search } from 'lucide-react';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
@@ -22,7 +22,7 @@ export function DetailSearch({ selectedMonth }: DetailSearchProps) {
   const [dataLoading, setDataLoading] = useState(false);
 
     const supabase = useMemo(
-      () => (typeof window !== 'undefined' ? getSupabase() : null),
+      () => (typeof window !== 'undefined' ? getSupabaseBrowserClient() : null),
       []
     );
 

--- a/components/finance/FinancialStatementsContent.tsx
+++ b/components/finance/FinancialStatementsContent.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
-import getSupabase from '@/lib/supabase/browser'; // ver.9 (2025-08-19 JST) - browser singleton client
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'; // ver.9 (2025-08-19 JST) - browser singleton client
 import { FileSpreadsheet, BarChart3, Calendar, FileText, ToggleLeft, ToggleRight } from 'lucide-react';
 
 import { BalanceSheet } from '@/components/finance/BalanceSheet';
@@ -46,7 +46,7 @@ export default function FinancialStatementsContent() {
   });
 
   const supabase = useMemo(
-    () => (typeof window !== 'undefined' ? getSupabase() : null),
+    () => (typeof window !== 'undefined' ? getSupabaseBrowserClient() : null),
     []
   );
 

--- a/components/food-store/CategoryManagementModal.tsx
+++ b/components/food-store/CategoryManagementModal.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 import { Plus, Edit2, Trash2, GripVertical } from "lucide-react"
 import {
   Table,
@@ -26,7 +26,7 @@ function CategoryManagementModal({ isOpen, onClose }: CategoryManagementModalPro
   const [newCategoryName, setNewCategoryName] = useState("")
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editingName, setEditingName] = useState("")
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   useEffect(() => {
     if (isOpen) {

--- a/components/food-store/FoodStoreCsvImportModal.tsx
+++ b/components/food-store/FoodStoreCsvImportModal.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import Papa from 'papaparse'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 
 interface FoodStoreCsvImportModalProps {
   isOpen?: boolean
@@ -30,7 +30,7 @@ export default function FoodStoreCsvImportModal({
   const [isImporting, setIsImporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   // モーダルが開いた時に年月を自動セット
   useEffect(() => {

--- a/components/food-store/ProductCategoryMappingModal.tsx
+++ b/components/food-store/ProductCategoryMappingModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'
 
 interface ProductCategoryMappingModalProps {
   isOpen: boolean
@@ -36,7 +36,7 @@ function ProductCategoryMappingModal({
   const [grossProfitRates, setGrossProfitRates] = useState<{[key: number]: string}>({})
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
-  const supabase = createClientComponentClient()
+  const supabase = getSupabaseBrowserClient()
 
   useEffect(() => {
     if (isOpen) {

--- a/components/websales-site-trend.tsx
+++ b/components/websales-site-trend.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts"
 import ClientOnly from '@/components/common/ClientOnly'; // ver.1 (2025-08-19 JST) - client-only charts
-import getSupabase from '@/lib/supabase/browser'; // ver.1 (2025-08-19 JST) - browser singleton client
-const supabase = getSupabase(); // ver.1 (2025-08-19 JST)
+import { getSupabaseBrowserClient } from '@/lib/supabase/browser'; // ver.1 (2025-08-19 JST) - browser singleton client
+const supabase = getSupabaseBrowserClient(); // ver.1 (2025-08-19 JST)
 
 const SITES = [
   { key: "amazon", name: "Amazon", color: "#3b82f6" },

--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,12 +1,26 @@
-'use client';
-// ver.1 (2025-08-19 JST) - singleton supabase client
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const STORAGE_KEY = 'sb-tsai-sales-db';
-let _sb: SupabaseClient | undefined;
-export default function getSupabase() {
-  if (_sb) return _sb;
-  _sb = createClient(url, anon, { auth: { persistSession: true, storageKey: STORAGE_KEY } });
-  return _sb;
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __supabaseClient__: SupabaseClient | undefined;
 }
+
+export function getSupabaseBrowserClient(): SupabaseClient {
+  if (typeof window === 'undefined') {
+    throw new Error('getSupabaseBrowserClient must be called on the client');
+  }
+  if (!globalThis.__supabaseClient__) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+    globalThis.__supabaseClient__ = createClient(url, key, {
+      auth: {
+        // プロジェクト固有のstorageKeyにして重複を避ける
+        storageKey: 'sb-tsai-sales-db',
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    });
+  }
+  return globalThis.__supabaseClient__!;
+}
+


### PR DESCRIPTION
## Summary
- add a browser Supabase helper that ensures a single client instance
- render dashboard dates client-side to avoid hydration mismatch
- switch components to use the singleton Supabase client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy SUPABASE_JWT_SECRET=dummy npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a571e050b48321b62f45852f98c5ae