### PR TITLE
Make web-sales pages client-only

### DIFF
--- a/app/web-sales/dashboard/page.tsx
+++ b/app/web-sales/dashboard/page.tsx
@@ -1,5 +1,8 @@
-// /app/web-sales/dashboard/page.tsx ver.27 (import パス修正版)
-"use client"
+// /app/web-sales/dashboard/page.tsx
+'use client'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const fetchCache = 'force-no-store'
 
 import { useState, useEffect, Suspense, useCallback, useRef } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
@@ -13,8 +16,6 @@ import AdvertisingCostModal from "@/components/AdvertisingCostModal"
 import { supabase } from "@/lib/supabase"
 import { WebSalesData } from "@/types/db"
 import { Plus, Trash2, DollarSign } from "lucide-react"
-
-export const dynamic = 'force-dynamic'
 
 type ViewMode = 'month' | 'period';
 

--- a/app/web-sales/input/page.tsx
+++ b/app/web-sales/input/page.tsx
@@ -1,4 +1,8 @@
-"use client"
+// /app/web-sales/input/page.tsx
+'use client'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const fetchCache = 'force-no-store'
 import Sidebar from "@/components/sidebar"
 import WebSalesInputView from "@/components/web-sales-input-view"
 export default function WebSalesInputPage() {


### PR DESCRIPTION
## Summary
- Mark web-sales input page as a client-only route with dynamic rendering
- Mark web-sales dashboard page as a client-only route with dynamic rendering

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a585e488148321a03698190c880331