### PR TITLE
refactor: use browser Supabase singleton

### DIFF
--- a/components/finance/BalanceSheet.tsx
+++ b/components/finance/BalanceSheet.tsx
@@ -2,22 +2,7 @@
 
 import * as React from "react";
 import { useEffect, useMemo, useState } from "react";
-import * as SB from "@/lib/supabase/browser"; // named / default / instance どれでも対応
-
-// --- Supabase 取得（関数なら実行・インスタンスならそのまま） -------------------------
-function getSupabaseBrowserClient(): any {
-  const mod: any = SB;
-  const exp =
-    mod.createClient ?? // named: export const createClient = ...
-    mod.default ??       // default: export default function createClient() { ... } もしくは default が instance
-    mod.supabase ??      // たまに supabase として出していることがある
-    mod.client;
-
-  if (typeof exp === "function") return exp();       // ファクトリー関数
-  if (exp && typeof exp === "object") return exp;    // すでに生成済みインスタンス
-  throw new Error("Supabase browser client export is invalid");
-}
-// -----------------------------------------------------------------------------
+import { supabase } from "@/lib/supabase/browser";
 
 type Side = "assets" | "liabilities" | "equity";
 
@@ -52,8 +37,6 @@ function toMonthFirstISO(x: string | Date): string {
 }
 
 export default function BalanceSheet({ targetMonth, warnThreshold = 0 }: Props) {
-  // ✔ ここで1回だけ取得（関数でもインスタンスでもOK）
-  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -112,7 +95,7 @@ export default function BalanceSheet({ targetMonth, warnThreshold = 0 }: Props) 
     return () => {
       cancelled = true;
     };
-  }, [supabase, monthISO]);
+  }, [monthISO]);
 
   // 検算（符号付き）：A - (L + E)
   const gap = useMemo(

--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,26 +1,44 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+// /lib/supabase/browser.ts
+// 後方互換あり：named(default) / 関数 / 既成インスタンス すべて吸収
+import { createBrowserClient, type SupabaseClient } from "@supabase/ssr";
 
+const URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+// HMR/複数バンドルでも単一化（同一タブ内で1個だけ）
 declare global {
   // eslint-disable-next-line no-var
-  var __supabaseClient__: SupabaseClient | undefined;
+  var __SB_SINGLETON__: SupabaseClient | undefined;
 }
 
+function _newClient() {
+  return createBrowserClient(URL, KEY, {
+    auth: {
+      // 複数クライアントを避けるため storageKey を固定
+      storageKey: "sb-auth",
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  });
+}
+
+// 常に同じインスタンスを返す
 export function getSupabaseBrowserClient(): SupabaseClient {
-  if (typeof window === 'undefined') {
-    throw new Error('getSupabaseBrowserClient must be called on the client');
+  if (typeof window === "undefined") {
+    // ブラウザ専用。SSR は /lib/supabase/server.ts を使う
+    throw new Error("Use server client on the server side");
   }
-  if (!globalThis.__supabaseClient__) {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-    globalThis.__supabaseClient__ = createClient(url, key, {
-      auth: {
-        // プロジェクト固有のstorageKeyにして重複を避ける
-        storageKey: 'sb-tsai-sales-db',
-        persistSession: true,
-        autoRefreshToken: true,
-      },
-    });
+  if (!globalThis.__SB_SINGLETON__) {
+    globalThis.__SB_SINGLETON__ = _newClient();
   }
-  return globalThis.__supabaseClient__!;
+  return globalThis.__SB_SINGLETON__;
 }
 
+// 互換用エクスポート（既存コードを壊さない）
+export const createClient = getSupabaseBrowserClient; // named import 互換
+const defaultExport = getSupabaseBrowserClient;       // default import 互換
+export default defaultExport;
+
+// “そのまま使いたい派”向けのインスタンス（読むだけ）
+export const supabase = getSupabaseBrowserClient();

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,19 @@
+import { cookies } from "next/headers";
+import { createServerClient, type SupabaseClient } from "@supabase/ssr";
+
+export function getSupabaseServerClient(): SupabaseClient {
+  const cookieStore = cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => cookieStore.get(name)?.value,
+        set: (name: string, value: string, options: any) =>
+          cookieStore.set({ name, value, ...options }),
+        remove: (name: string, options: any) =>
+          cookieStore.set({ name, value: "", ...options }),
+      },
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- replace Supabase browser helper with backward-compatible singleton
- add server-side Supabase client helper
- simplify BalanceSheet to use shared Supabase instance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6f2eb6408321bc5b1c3685b95370