### PR TITLE
feat: add annual plan dashboard

### DIFF
--- a/app/annual-plan/page.tsx
+++ b/app/annual-plan/page.tsx
@@ -1,0 +1,19 @@
+import AnnualPlanEditor from "@/components/annual/AnnualPlanEditor";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default function Page() {
+  return (
+    <main className="p-6 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">年間目標ダッシュボード（当期）</h1>
+        <p className="text-sm text-neutral-500">
+          前年度実績・実績はシステム自動集計／今年度目標と営業目標は手入力保存
+        </p>
+      </header>
+      <AnnualPlanEditor />
+    </main>
+  );
+}

--- a/app/api/annual-plan/data/route.ts
+++ b/app/api/annual-plan/data/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+const CHANNELS = [
+  { code: "SHOKU", label: "食のブランド館（道の駅）" },
+  { code: "STORE", label: "会津ブランド館（店舗）" },
+  { code: "WEB", label: "会津ブランド館（ネット販売）" },
+  { code: "WHOLESALE", label: "卸売上・OEM" },
+] as const;
+
+function fyNow() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1; // 1-12
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1)); // 8月
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1)); // 翌年8月
+  const prevStart = new Date(Date.UTC(fyStartYear - 1, 7, 1));
+  const prevEnd = new Date(Date.UTC(fyStartYear, 7, 1));
+  const months: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
+    months.push(d.toISOString().slice(0, 10)); // YYYY-MM-DD(月初)
+  }
+  return {
+    fyLabel: `FY${fyStartYear + 1 - 2000}`,
+    fyStartISO: start.toISOString().slice(0, 10),
+    fyEndISO: end.toISOString().slice(0, 10),
+    prevStartISO: prevStart.toISOString().slice(0, 10),
+    prevEndISO: prevEnd.toISOString().slice(0, 10),
+    months,
+  };
+}
+
+function ym(s: string) { return s.slice(0,7); }
+function toNum(v: any) { return typeof v === "string" ? Number(v) : (v ?? 0); }
+
+export async function GET() {
+  try {
+    const { fyLabel, fyStartISO, fyEndISO, prevStartISO, prevEndISO, months } = fyNow();
+
+    // 当期実績
+    const sqlCurr = `
+      select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+      from kpi.kpi_sales_monthly_computed_v2
+      where fiscal_month >= $1 and fiscal_month < $2
+      group by 1,2
+    `;
+    const curr = await pool.query(sqlCurr, [fyStartISO, fyEndISO]);
+
+    // 前年度実績
+    const sqlPrev = `
+      select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+      from kpi.kpi_sales_monthly_computed_v2
+      where fiscal_month >= $1 and fiscal_month < $2
+      group by 1,2
+    `;
+    const prev = await pool.query(sqlPrev, [prevStartISO, prevEndISO]);
+
+    // 今年度目標（手入力）
+    const targets = await pool.query(
+      `select channel_code, month_date as m, target_amount_yen as amt
+       from kpi.annual_targets_v1
+       where fiscal_year_start = $1`,
+       [fyStartISO]
+    );
+
+    // 営業目標（手入力）
+    const goals = await pool.query(
+      `select metric_code, month_date as m, value
+       from kpi.sales_goals_manual_v1
+       where fiscal_year_start = $1`,
+       [fyStartISO]
+    );
+
+    // 連想に整形
+    const currMap = new Map<string, number>();
+    curr.rows.forEach(r => currMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+
+    const prevMap = new Map<string, number>();
+    prev.rows.forEach(r => prevMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+
+    const tgtMap = new Map<string, number>();
+    targets.rows.forEach(r => tgtMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+
+    const goalMap = new Map<string, number>();
+    goals.rows.forEach(r => goalMap.set(`${r.metric_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.value)));
+
+    // レスポンス組み立て
+    const channelBlocks = CHANNELS.map(ch => {
+      const rows = months.map(m => {
+        const k = `${ch.code}|${m}`;
+        const lastYearM = new Date(m); lastYearM.setUTCFullYear(lastYearM.getUTCFullYear() - 1);
+        const prevK = `${ch.code}|${lastYearM.toISOString().slice(0,10)}`;
+        const actual = currMap.get(k) ?? 0;
+        const ly = prevMap.get(prevK) ?? 0;
+        const target = tgtMap.get(k) ?? 0;
+        const rate = target === 0 ? null : (actual / target) * 100;
+        const yoy = ly === 0 ? null : (actual / ly) * 100;
+        return { m, ym: ym(m), target, actual, last_year: ly, rate, yoy };
+      });
+      return { channel: ch, rows };
+    });
+
+    // 営業目標ブロック（6指標）
+    const METRICS = [
+      { code:"new_clients_target", label:"新規取引先・OEM開拓目標件数（目標）" },
+      { code:"new_clients_actual", label:"新規取引先・OEM開拓（実績）" },
+      { code:"proposals_target", label:"追加商品提案採用（目標）" },
+      { code:"proposals_actual", label:"追加商品提案採用（実績）" },
+      { code:"oem_target", label:"OEM製造（目標）" },
+      { code:"oem_actual", label:"OEM製造（実績）" },
+    ] as const;
+
+    const salesGoals = METRICS.map(mt => ({
+      metric: mt, rows: months.map(m => ({ m, ym: ym(m), val: goalMap.get(`${mt.code}|${m}`) ?? 0 }))
+    }));
+
+    return NextResponse.json({
+      ok: true,
+      fy: { label: fyLabel, start: fyStartISO, end: fyEndISO },
+      months: months.map(m => ({ m, ym: ym(m) })),
+      channels: CHANNELS,
+      channelBlocks,
+      salesGoals,
+    });
+  } catch (e: any) {
+    return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status: 500 });
+  }
+}

--- a/app/api/annual-plan/export.csv/route.ts
+++ b/app/api/annual-plan/export.csv/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+function fyNow() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1));
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1));
+  const months: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
+    months.push(d.toISOString().slice(0, 10));
+  }
+  return { startISO: start.toISOString().slice(0,10), endISO: end.toISOString().slice(0,10), fyLabel:`FY${fyStartYear + 1 - 2000}`, months };
+}
+
+function csvEscape(s: string){return /[",\n]/.test(s)?`"${s.replace(/"/g,'""')}"`:s;}
+function toNum(v:any){return typeof v==="string"?Number(v):(v??0);}
+
+export async function GET() {
+  const { startISO, endISO, fyLabel, months } = fyNow();
+
+  // 実績
+  const curr = await pool.query(`
+    select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+    from kpi.kpi_sales_monthly_computed_v2
+    where fiscal_month >= $1 and fiscal_month < $2
+    group by 1,2
+  `,[startISO, endISO]);
+
+  // 前年
+  const prev = await pool.query(`
+    select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+    from kpi.kpi_sales_monthly_computed_v2
+    where fiscal_month >= ($1::date - interval '1 year') and fiscal_month < $1
+    group by 1,2
+  `,[startISO]);
+
+  const targets = await pool.query(`
+    select channel_code, month_date as m, target_amount_yen as amt
+    from kpi.annual_targets_v1 where fiscal_year_start = $1
+  `,[startISO]);
+
+  const cm = new Map<string, number>(); curr.rows.forEach(r=>cm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+  const pm = new Map<string, number>(); prev.rows.forEach(r=>pm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+  const tm = new Map<string, number>(); targets.rows.forEach(r=>tm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+
+  const CHANNELS = ["SHOKU","STORE","WEB","WHOLESALE"];
+  const LABELS: Record<string,string> = {
+    SHOKU:"食のブランド館（道の駅）",
+    STORE:"会津ブランド館（店舗）",
+    WEB:"会津ブランド館（ネット販売）",
+    WHOLESALE:"卸売上・OEM"
+  };
+
+  const header = ["category","row","total",...months.map(m=>m.slice(0,7))].join(",");
+  const lines = [header];
+
+  for (const code of CHANNELS) {
+    const rowPrev:number[]=[]; const rowTgt:number[]=[]; const rowAct:number[]=[];
+    let sumPrev=0, sumTgt=0, sumAct=0;
+    for (const m of months) {
+      const lastYear = new Date(m); lastYear.setUTCFullYear(lastYear.getUTCFullYear()-1);
+      const prevK = `${code}|${lastYear.toISOString().slice(0,10)}`;
+      const tgtK = `${code}|${m}`;
+      const actK = `${code}|${m}`;
+      const pv = pm.get(prevK)??0; const tv = tm.get(tgtK)??0; const av = cm.get(actK)??0;
+      sumPrev+=pv; sumTgt+=tv; sumAct+=av;
+      rowPrev.push(pv); rowTgt.push(tv); rowAct.push(av);
+    }
+    lines.push([csvEscape(LABELS[code]), "前年度実績", String(sumPrev), ...rowPrev.map(String)].join(","));
+    lines.push([csvEscape(LABELS[code]), "今年度目標", String(sumTgt), ...rowTgt.map(String)].join(","));
+    lines.push([csvEscape(LABELS[code]), "実績", String(sumAct), ...rowAct.map(String)].join(","));
+  }
+
+  const csv = lines.join("\n");
+  const filename = `annual_plan_${fyLabel}.csv`;
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/api/annual-plan/save/route.ts
+++ b/app/api/annual-plan/save/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+/*
+POST 期待ペイロード:
+{
+  fiscal_year_start: "YYYY-MM-DD",
+  targets: [ { channel_code:"WEB", month_date:"YYYY-MM-01", target_amount_yen:12345 }, ... ],
+  goals:   [ { metric_code:"new_clients_target", month_date:"YYYY-MM-01", value: 3 }, ... ]
+}
+*/
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { fiscal_year_start, targets = [], goals = [] } = body ?? {};
+    if (!fiscal_year_start) throw new Error("fiscal_year_start is required");
+
+    const client = await pool.connect();
+    try {
+      await client.query("begin");
+
+      if (targets.length) {
+        const sql = `
+          insert into kpi.annual_targets_v1 (fiscal_year_start, channel_code, month_date, target_amount_yen)
+          values ${targets.map((_,i)=>`($1, $${i*3+2}, $${i*3+3}, $${i*3+4})`).join(",")}
+          on conflict (fiscal_year_start, channel_code, month_date)
+          do update set target_amount_yen = excluded.target_amount_yen
+        `;
+        const params: any[] = [fiscal_year_start];
+        for (const t of targets) params.push(t.channel_code, t.month_date, t.target_amount_yen ?? 0);
+        await client.query(sql, params);
+      }
+
+      if (goals.length) {
+        const sql = `
+          insert into kpi.sales_goals_manual_v1 (fiscal_year_start, month_date, metric_code, value)
+          values ${goals.map((_,i)=>`($1, $${i*3+2}, $${i*3+3}, $${i*3+4})`).join(",")}
+          on conflict (fiscal_year_start, month_date, metric_code)
+          do update set value = excluded.value
+        `;
+        const params: any[] = [fiscal_year_start];
+        for (const g of goals) params.push(g.month_date, g.metric_code, g.value ?? 0);
+        await client.query(sql, params);
+      }
+
+      await client.query("commit");
+      return NextResponse.json({ ok:true });
+    } catch (e) {
+      await client.query("rollback");
+      throw e;
+    } finally {
+      client.release();
+    }
+  } catch (e: any) {
+    return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status: 500 });
+  }
+}

--- a/components/annual/AnnualPlanEditor.tsx
+++ b/components/annual/AnnualPlanEditor.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type Resp = {
+  ok: boolean;
+  fy: { label: string; start: string; end: string };
+  months: { m: string; ym: string }[];
+  channels: { code: string; label: string }[];
+  channelBlocks: {
+    channel: { code: string; label: string };
+    rows: { m: string; ym: string; target: number; actual: number; last_year: number; rate: number|null; yoy: number|null }[];
+  }[];
+  salesGoals: {
+    metric: { code: string; label: string };
+    rows: { m: string; ym: string; val: number }[];
+  }[];
+};
+
+const JPY = (n: number) =>
+  new Intl.NumberFormat("ja-JP", { style: "currency", currency: "JPY", maximumFractionDigits: 0 }).format(n);
+
+export default function AnnualPlanEditor() {
+  const [data, setData] = useState<Resp | null>(null);
+  const [targets, setTargets] = useState<Record<string, number>>({}); // key: ch|m
+  const [goals, setGoals] = useState<Record<string, number>>({});     // key: metric|m
+  const [busy, setBusy] = useState(false);
+  const months = data?.months ?? [];
+
+  useEffect(() => {
+    fetch("/api/annual-plan/data").then(r=>r.json()).then((d:Resp)=>{
+      setData(d);
+      // 既存の目標を初期値に展開
+      const t: Record<string,number> = {};
+      d.channelBlocks.forEach(cb => cb.rows.forEach(r => { t[`${cb.channel.code}|${r.m}`] = r.target ?? 0; }));
+      setTargets(t);
+      const g: Record<string,number> = {};
+      d.salesGoals.forEach(sg => sg.rows.forEach(r => { g[`${sg.metric.code}|${r.m}`] = r.val ?? 0; }));
+      setGoals(g);
+    });
+  }, []);
+
+  const totalByRow = (rows: {target:number; actual:number; last_year:number}[]) => ({
+    tgt: rows.reduce((s,r)=>s+(r.target||0),0),
+    act: rows.reduce((s,r)=>s+(r.actual||0),0),
+    ly:  rows.reduce((s,r)=>s+(r.last_year||0),0),
+  });
+
+  const onChangeTarget = (ch:string, m:string, v:string) => {
+    const n = Number(v.replaceAll(",",""));
+    setTargets(prev => ({...prev, [`${ch}|${m}`]: isFinite(n) ? n : 0}));
+  };
+
+  const onChangeGoal = (code:string, m:string, v:string) => {
+    const n = Number(v.replaceAll(",",""));
+    setGoals(prev => ({...prev, [`${code}|${m}`]: isFinite(n) ? n : 0}));
+  };
+
+  const save = async () => {
+    if (!data) return;
+    setBusy(true);
+    try {
+      const payload = {
+        fiscal_year_start: data.fy.start,
+        targets: Object.entries(targets).map(([k,val])=>{
+          const [channel_code, month_date] = k.split("|");
+          return { channel_code, month_date, target_amount_yen: val ?? 0 };
+        }),
+        goals: Object.entries(goals).map(([k,val])=>{
+          const [metric_code, month_date] = k.split("|");
+          return { metric_code, month_date, value: val ?? 0 };
+        }),
+      };
+      const res = await fetch("/api/annual-plan/save", { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify(payload) });
+      if (!res.ok) throw new Error(await res.text());
+      alert("保存しました。");
+    } catch (e:any) {
+      alert("保存に失敗: " + (e?.message || e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!data) return <div className="text-sm text-neutral-500">読み込み中…</div>;
+
+  return (
+    <div className="space-y-10">
+      {/* チャネル別ブロック（PDFのセクション相当） */}
+      {data.channelBlocks.map((cb) => {
+        const tot = totalByRow(cb.rows);
+        return (
+          <section key={cb.channel.code} className="space-y-2">
+            <h2 className="text-lg font-semibold">{cb.channel.label}</h2>
+            <div className="overflow-x-auto rounded-2xl border">
+              <table className="min-w-[1000px] w-full text-sm">
+                <thead className="bg-neutral-50">
+                  <tr>
+                    <th className="px-3 py-2 text-left w-[160px]">科目</th>
+                    {months.map(({ym},i)=>(
+                      <th key={i} className="px-3 py-2 text-right">{ym}</th>
+                    ))}
+                    <th className="px-3 py-2 text-right">計</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {/* 前年度実績（readonly） */}
+                  <tr className="border-t">
+                    <td className="px-3 py-2 font-medium">前年度実績</td>
+                    {cb.rows.map((r,i)=> <td key={i} className="px-3 py-2 text-right">{JPY(r.last_year||0)}</td>)}
+                    <td className="px-3 py-2 text-right">{JPY(tot.ly)}</td>
+                  </tr>
+                  {/* 今年度目標（editable） */}
+                  <tr className="border-t bg-neutral-50/50">
+                    <td className="px-3 py-2 font-medium">今年度目標</td>
+                    {cb.rows.map((r,i)=>{
+                      const key = `${cb.channel.code}|${r.m}`;
+                      return (
+                        <td key={i} className="px-3 py-2 text-right">
+                          <input
+                            className="w-28 border rounded px-2 py-1 text-right"
+                            value={targets[key] ?? 0}
+                            onChange={(e)=>onChangeTarget(cb.channel.code, r.m, e.target.value)}
+                          />
+                        </td>
+                      );
+                    })}
+                    <td className="px-3 py-2 text-right">{JPY(cb.rows.reduce((s,r)=>s+(targets[`${cb.channel.code}|${r.m}`] ?? r.target ?? 0),0))}</td>
+                  </tr>
+                  {/* 実績（readonly） */}
+                  <tr className="border-t">
+                    <td className="px-3 py-2 font-medium">実績</td>
+                    {cb.rows.map((r,i)=> <td key={i} className="px-3 py-2 text-right">{JPY(r.actual||0)}</td>)}
+                    <td className="px-3 py-2 text-right">{JPY(tot.act)}</td>
+                  </tr>
+                  {/* 目標達成率（％） */}
+                  <tr className="border-t">
+                    <td className="px-3 py-2 font-medium">目標達成率（％）</td>
+                    {cb.rows.map((r,i)=>{
+                      const tgt = targets[`${cb.channel.code}|${r.m}`] ?? r.target ?? 0;
+                      const pct = tgt === 0 ? "—" : `${((r.actual||0)/tgt*100).toFixed(0)}%`;
+                      return <td key={i} className="px-3 py-2 text-right">{pct}</td>;
+                    })}
+                    <td className="px-3 py-2 text-right">
+                      {(()=>{
+                        const tgtSum = cb.rows.reduce((s,r)=>s+(targets[`${cb.channel.code}|${r.m}`] ?? r.target ?? 0),0);
+                        return tgtSum===0?"—":`${(tot.act/tgtSum*100).toFixed(0)}%`;
+                      })()}
+                    </td>
+                  </tr>
+                  {/* 前年度対比（％） */}
+                  <tr className="border-t">
+                    <td className="px-3 py-2 font-medium">前年度対比（％）</td>
+                    {cb.rows.map((r,i)=>{
+                      const ly = r.last_year||0;
+                      const pct = ly===0?"—":`${((r.actual||0)/ly*100).toFixed(0)}%`;
+                      return <td key={i} className="px-3 py-2 text-right">{pct}</td>;
+                    })}
+                    <td className="px-3 py-2 text-right">{tot.ly===0?"—":`${(tot.act/tot.ly*100).toFixed(0)}%`}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+        );
+      })}
+
+      {/* 営業目標（手入力） */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold">営業目標（手入力）</h2>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[1000px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[240px]">項目</th>
+                {months.map(({ym},i)=> <th key={i} className="px-3 py-2 text-right">{ym}</th>)}
+                <th className="px-3 py-2 text-right">計</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.salesGoals.map((sg,idx)=>{
+                const rowSum = sg.rows.reduce((s,r)=>s+(goals[`${sg.metric.code}|${r.m}`] ?? r.val ?? 0),0);
+                return (
+                  <tr key={idx} className="border-t">
+                    <td className="px-3 py-2 font-medium">{sg.metric.label}</td>
+                    {sg.rows.map((r,i)=>{
+                      const key = `${sg.metric.code}|${r.m}`;
+                      return (
+                        <td key={i} className="px-3 py-2 text-right">
+                          <input
+                            className="w-20 border rounded px-2 py-1 text-right"
+                            value={goals[key] ?? 0}
+                            onChange={(e)=>onChangeGoal(sg.metric.code, r.m, e.target.value)}
+                          />
+                        </td>
+                      );
+                    })}
+                    <td className="px-3 py-2 text-right">{rowSum}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* 操作 */}
+      <div className="flex items-center gap-3">
+        <button onClick={save} disabled={busy} className="px-4 py-2 rounded-xl border shadow-sm disabled:opacity-60">
+          {busy ? "保存中…" : "保存"}
+        </button>
+        <a href="/api/annual-plan/export.csv" className="px-4 py-2 rounded-xl border shadow-sm">CSVダウンロード</a>
+      </div>
+    </div>
+  );
+}

--- a/sql/20250908_annual_plan.sql
+++ b/sql/20250908_annual_plan.sql
@@ -1,0 +1,20 @@
+-- 年間目標・営業目標の手入力保存用（RLSなし・最小構成）
+create schema if not exists kpi;
+
+create table if not exists kpi.annual_targets_v1 (
+  id bigserial primary key,
+  fiscal_year_start date not null,               -- 例: 2025-08-01
+  channel_code text not null check (channel_code in ('WEB','WHOLESALE','STORE','SHOKU')),
+  month_date date not null,                      -- 月初
+  target_amount_yen numeric(14,0) not null default 0,
+  unique (fiscal_year_start, channel_code, month_date)
+);
+
+create table if not exists kpi.sales_goals_manual_v1 (
+  id bigserial primary key,
+  fiscal_year_start date not null,
+  month_date date not null,                      -- 月初
+  metric_code text not null,                     -- 例: new_clients_target / new_clients_actual / proposals_target / proposals_actual / oem_target / oem_actual
+  value numeric(14,2) not null default 0,
+  unique (fiscal_year_start, month_date, metric_code)
+);


### PR DESCRIPTION
## Summary
- add SQL tables for annual sales targets and manual goals
- implement annual plan page with editable targets and goals
- provide data, save, and CSV export APIs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for config)


------
https://chatgpt.com/codex/tasks/task_e_68be787d2f4c8321b925fb4c6d4d6552