### PR TITLE
fix: force annual plan APIs to run dynamically

### DIFF
--- a/app/api/annual-plan/data/route.ts
+++ b/app/api/annual-plan/data/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from "next/server";
 import { Pool } from "pg";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
@@ -18,16 +21,16 @@ const CHANNELS = [
 function fyNow() {
   const now = new Date();
   const y = now.getUTCFullYear();
-  const m = now.getUTCMonth() + 1; // 1-12
+  const m = now.getUTCMonth() + 1;
   const fyStartYear = m >= 8 ? y : y - 1;
-  const start = new Date(Date.UTC(fyStartYear, 7, 1)); // 8月
-  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1)); // 翌年8月
+  const start = new Date(Date.UTC(fyStartYear, 7, 1));
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1));
   const prevStart = new Date(Date.UTC(fyStartYear - 1, 7, 1));
   const prevEnd = new Date(Date.UTC(fyStartYear, 7, 1));
   const months: string[] = [];
   for (let i = 0; i < 12; i++) {
     const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
-    months.push(d.toISOString().slice(0, 10)); // YYYY-MM-DD(月初)
+    months.push(d.toISOString().slice(0, 10));
   }
   return {
     fyLabel: `FY${fyStartYear + 1 - 2000}`,
@@ -38,7 +41,6 @@ function fyNow() {
     months,
   };
 }
-
 function ym(s: string) { return s.slice(0,7); }
 function toNum(v: any) { return typeof v === "string" ? Number(v) : (v ?? 0); }
 
@@ -46,91 +48,86 @@ export async function GET() {
   try {
     const { fyLabel, fyStartISO, fyEndISO, prevStartISO, prevEndISO, months } = fyNow();
 
-    // 当期実績
-    const sqlCurr = `
-      select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
-      from kpi.kpi_sales_monthly_computed_v2
-      where fiscal_month >= $1 and fiscal_month < $2
-      group by 1,2
-    `;
-    const curr = await pool.query(sqlCurr, [fyStartISO, fyEndISO]);
+    const client = await pool.connect();
+    try {
+      const sqlCurr = `
+        select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+        from kpi.kpi_sales_monthly_computed_v2
+        where fiscal_month >= $1 and fiscal_month < $2
+        group by 1,2
+      `;
+      const curr = await client.query(sqlCurr, [fyStartISO, fyEndISO]);
 
-    // 前年度実績
-    const sqlPrev = `
-      select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
-      from kpi.kpi_sales_monthly_computed_v2
-      where fiscal_month >= $1 and fiscal_month < $2
-      group by 1,2
-    `;
-    const prev = await pool.query(sqlPrev, [prevStartISO, prevEndISO]);
+      const sqlPrev = `
+        select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+        from kpi.kpi_sales_monthly_computed_v2
+        where fiscal_month >= $1 and fiscal_month < $2
+        group by 1,2
+      `;
+      const prev = await client.query(sqlPrev, [prevStartISO, prevEndISO]);
 
-    // 今年度目標（手入力）
-    const targets = await pool.query(
-      `select channel_code, month_date as m, target_amount_yen as amt
-       from kpi.annual_targets_v1
-       where fiscal_year_start = $1`,
-       [fyStartISO]
-    );
+      const targets = await client.query(
+        `select channel_code, month_date as m, target_amount_yen as amt
+         from kpi.annual_targets_v1
+         where fiscal_year_start = $1`,
+         [fyStartISO]
+      );
 
-    // 営業目標（手入力）
-    const goals = await pool.query(
-      `select metric_code, month_date as m, value
-       from kpi.sales_goals_manual_v1
-       where fiscal_year_start = $1`,
-       [fyStartISO]
-    );
+      const goals = await client.query(
+        `select metric_code, month_date as m, value
+         from kpi.sales_goals_manual_v1
+         where fiscal_year_start = $1`,
+         [fyStartISO]
+      );
 
-    // 連想に整形
-    const currMap = new Map<string, number>();
-    curr.rows.forEach(r => currMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+      const currMap = new Map<string, number>();
+      curr.rows.forEach(r => currMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+      const prevMap = new Map<string, number>();
+      prev.rows.forEach(r => prevMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+      const tgtMap = new Map<string, number>();
+      targets.rows.forEach(r => tgtMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+      const goalMap = new Map<string, number>();
+      goals.rows.forEach(r => goalMap.set(`${r.metric_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.value)));
 
-    const prevMap = new Map<string, number>();
-    prev.rows.forEach(r => prevMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
-
-    const tgtMap = new Map<string, number>();
-    targets.rows.forEach(r => tgtMap.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
-
-    const goalMap = new Map<string, number>();
-    goals.rows.forEach(r => goalMap.set(`${r.metric_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.value)));
-
-    // レスポンス組み立て
-    const channelBlocks = CHANNELS.map(ch => {
-      const rows = months.map(m => {
-        const k = `${ch.code}|${m}`;
-        const lastYearM = new Date(m); lastYearM.setUTCFullYear(lastYearM.getUTCFullYear() - 1);
-        const prevK = `${ch.code}|${lastYearM.toISOString().slice(0,10)}`;
-        const actual = currMap.get(k) ?? 0;
-        const ly = prevMap.get(prevK) ?? 0;
-        const target = tgtMap.get(k) ?? 0;
-        const rate = target === 0 ? null : (actual / target) * 100;
-        const yoy = ly === 0 ? null : (actual / ly) * 100;
-        return { m, ym: ym(m), target, actual, last_year: ly, rate, yoy };
+      const channelBlocks = CHANNELS.map(ch => {
+        const rows = months.map(m => {
+          const k = `${ch.code}|${m}`;
+          const lastYearM = new Date(m); lastYearM.setUTCFullYear(lastYearM.getUTCFullYear() - 1);
+          const prevK = `${ch.code}|${lastYearM.toISOString().slice(0,10)}`;
+          const actual = currMap.get(k) ?? 0;
+          const ly = prevMap.get(prevK) ?? 0;
+          const target = tgtMap.get(k) ?? 0;
+          const rate = target === 0 ? null : (actual / target) * 100;
+          const yoy = ly === 0 ? null : (actual / ly) * 100;
+          return { m, ym: ym(m), target, actual, last_year: ly, rate, yoy };
+        });
+        return { channel: ch, rows };
       });
-      return { channel: ch, rows };
-    });
 
-    // 営業目標ブロック（6指標）
-    const METRICS = [
-      { code:"new_clients_target", label:"新規取引先・OEM開拓目標件数（目標）" },
-      { code:"new_clients_actual", label:"新規取引先・OEM開拓（実績）" },
-      { code:"proposals_target", label:"追加商品提案採用（目標）" },
-      { code:"proposals_actual", label:"追加商品提案採用（実績）" },
-      { code:"oem_target", label:"OEM製造（目標）" },
-      { code:"oem_actual", label:"OEM製造（実績）" },
-    ] as const;
+      const METRICS = [
+        { code:"new_clients_target", label:"新規取引先・OEM開拓目標件数（目標）" },
+        { code:"new_clients_actual", label:"新規取引先・OEM開拓（実績）" },
+        { code:"proposals_target", label:"追加商品提案採用（目標）" },
+        { code:"proposals_actual", label:"追加商品提案採用（実績）" },
+        { code:"oem_target", label:"OEM製造（目標）" },
+        { code:"oem_actual", label:"OEM製造（実績）" },
+      ] as const;
 
-    const salesGoals = METRICS.map(mt => ({
-      metric: mt, rows: months.map(m => ({ m, ym: ym(m), val: goalMap.get(`${mt.code}|${m}`) ?? 0 }))
-    }));
+      const salesGoals = METRICS.map(mt => ({
+        metric: mt, rows: months.map(m => ({ m, ym: ym(m), val: goalMap.get(`${mt.code}|${m}`) ?? 0 }))
+      }));
 
-    return NextResponse.json({
-      ok: true,
-      fy: { label: fyLabel, start: fyStartISO, end: fyEndISO },
-      months: months.map(m => ({ m, ym: ym(m) })),
-      channels: CHANNELS,
-      channelBlocks,
-      salesGoals,
-    });
+      return NextResponse.json({
+        ok: true,
+        fy: { label: fyLabel, start: fyStartISO, end: fyEndISO },
+        months: months.map(m => ({ m, ym: ym(m) })),
+        channels: CHANNELS,
+        channelBlocks,
+        salesGoals,
+      });
+    } finally {
+      client.release();
+    }
   } catch (e: any) {
     return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status: 500 });
   }

--- a/app/api/annual-plan/export.csv/route.ts
+++ b/app/api/annual-plan/export.csv/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { Pool } from "pg";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
 
+// --- DB ---
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: { rejectUnauthorized: false },
@@ -22,74 +26,84 @@ function fyNow() {
   }
   return { startISO: start.toISOString().slice(0,10), endISO: end.toISOString().slice(0,10), fyLabel:`FY${fyStartYear + 1 - 2000}`, months };
 }
-
 function csvEscape(s: string){return /[",\n]/.test(s)?`"${s.replace(/"/g,'""')}"`:s;}
 function toNum(v:any){return typeof v==="string"?Number(v):(v??0);}
 
 export async function GET() {
-  const { startISO, endISO, fyLabel, months } = fyNow();
+  try {
+    const { startISO, endISO, fyLabel, months } = fyNow();
 
-  // 実績
-  const curr = await pool.query(`
-    select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
-    from kpi.kpi_sales_monthly_computed_v2
-    where fiscal_month >= $1 and fiscal_month < $2
-    group by 1,2
-  `,[startISO, endISO]);
+    const poolClient = await pool.connect();
+    try {
+      // 実績（当期）
+      const curr = await poolClient.query(`
+        select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+        from kpi.kpi_sales_monthly_computed_v2
+        where fiscal_month >= $1 and fiscal_month < $2
+        group by 1,2
+      `,[startISO, endISO]);
 
-  // 前年
-  const prev = await pool.query(`
-    select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
-    from kpi.kpi_sales_monthly_computed_v2
-    where fiscal_month >= ($1::date - interval '1 year') and fiscal_month < $1
-    group by 1,2
-  `,[startISO]);
+      // 前年
+      const prev = await poolClient.query(`
+        select channel_code, date_trunc('month', fiscal_month)::date as m, sum(actual_amount_yen) as amt
+        from kpi.kpi_sales_monthly_computed_v2
+        where fiscal_month >= ($1::date - interval '1 year') and fiscal_month < $1
+        group by 1,2
+      `,[startISO]);
 
-  const targets = await pool.query(`
-    select channel_code, month_date as m, target_amount_yen as amt
-    from kpi.annual_targets_v1 where fiscal_year_start = $1
-  `,[startISO]);
+      // 今年度目標（手入力）
+      const targets = await poolClient.query(`
+        select channel_code, month_date as m, target_amount_yen as amt
+        from kpi.annual_targets_v1 where fiscal_year_start = $1
+      `,[startISO]);
 
-  const cm = new Map<string, number>(); curr.rows.forEach(r=>cm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
-  const pm = new Map<string, number>(); prev.rows.forEach(r=>pm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
-  const tm = new Map<string, number>(); targets.rows.forEach(r=>tm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+      const cm = new Map<string, number>(); curr.rows.forEach(r=>cm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+      const pm = new Map<string, number>(); prev.rows.forEach(r=>pm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
+      const tm = new Map<string, number>(); targets.rows.forEach(r=>tm.set(`${r.channel_code}|${r.m.toISOString().slice(0,10)}`, toNum(r.amt)));
 
-  const CHANNELS = ["SHOKU","STORE","WEB","WHOLESALE"];
-  const LABELS: Record<string,string> = {
-    SHOKU:"食のブランド館（道の駅）",
-    STORE:"会津ブランド館（店舗）",
-    WEB:"会津ブランド館（ネット販売）",
-    WHOLESALE:"卸売上・OEM"
-  };
+      const CHANNELS = ["SHOKU","STORE","WEB","WHOLESALE"];
+      const LABELS: Record<string,string> = {
+        SHOKU:"食のブランド館（道の駅）",
+        STORE:"会津ブランド館（店舗）",
+        WEB:"会津ブランド館（ネット販売）",
+        WHOLESALE:"卸売上・OEM"
+      };
 
-  const header = ["category","row","total",...months.map(m=>m.slice(0,7))].join(",");
-  const lines = [header];
+      const header = ["category","row","total",...months.map(m=>m.slice(0,7))].join(",");
+      const lines = [header];
 
-  for (const code of CHANNELS) {
-    const rowPrev:number[]=[]; const rowTgt:number[]=[]; const rowAct:number[]=[];
-    let sumPrev=0, sumTgt=0, sumAct=0;
-    for (const m of months) {
-      const lastYear = new Date(m); lastYear.setUTCFullYear(lastYear.getUTCFullYear()-1);
-      const prevK = `${code}|${lastYear.toISOString().slice(0,10)}`;
-      const tgtK = `${code}|${m}`;
-      const actK = `${code}|${m}`;
-      const pv = pm.get(prevK)??0; const tv = tm.get(tgtK)??0; const av = cm.get(actK)??0;
-      sumPrev+=pv; sumTgt+=tv; sumAct+=av;
-      rowPrev.push(pv); rowTgt.push(tv); rowAct.push(av);
+      for (const code of CHANNELS) {
+        const rowPrev:number[]=[]; const rowTgt:number[]=[]; const rowAct:number[]=[];
+        let sumPrev=0, sumTgt=0, sumAct=0;
+        for (const m of months) {
+          const lastYear = new Date(m); lastYear.setUTCFullYear(lastYear.getUTCFullYear()-1);
+          const prevK = `${code}|${lastYear.toISOString().slice(0,10)}`;
+          const tgtK = `${code}|${m}`;
+          const actK = `${code}|${m}`;
+          const pv = pm.get(prevK)??0; const tv = tm.get(tgtK)??0; const av = cm.get(actK)??0;
+          sumPrev+=pv; sumTgt+=tv; sumAct+=av;
+          rowPrev.push(pv); rowTgt.push(tv); rowAct.push(av);
+        }
+        lines.push([csvEscape(LABELS[code]), "前年度実績", String(sumPrev), ...rowPrev.map(String)].join(","));
+        lines.push([csvEscape(LABELS[code]), "今年度目標", String(sumTgt), ...rowTgt.map(String)].join(","));
+        lines.push([csvEscape(LABELS[code]), "実績", String(sumAct), ...rowAct.map(String)].join(","));
+      }
+
+      const csv = lines.join("\n");
+      const filename = `annual_plan_${fyLabel}.csv`;
+      return new NextResponse(csv, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+          "Cache-Control": "no-store",
+        },
+      });
+    } finally {
+      poolClient.release();
     }
-    lines.push([csvEscape(LABELS[code]), "前年度実績", String(sumPrev), ...rowPrev.map(String)].join(","));
-    lines.push([csvEscape(LABELS[code]), "今年度目標", String(sumTgt), ...rowTgt.map(String)].join(","));
-    lines.push([csvEscape(LABELS[code]), "実績", String(sumAct), ...rowAct.map(String)].join(","));
+  } catch (e: any) {
+    // テーブル未作成などもここでキャッチ（ビルド時に失敗させない）
+    return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status: 500 });
   }
-
-  const csv = lines.join("\n");
-  const filename = `annual_plan_${fyLabel}.csv`;
-  return new NextResponse(csv, {
-    status: 200,
-    headers: {
-      "Content-Type": "text/csv; charset=utf-8",
-      "Content-Disposition": `attachment; filename="${filename}"`,
-      "Cache-Control": "no-store",
-    },
-  });
 }

--- a/app/api/annual-plan/save/route.ts
+++ b/app/api/annual-plan/save/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from "next/server";
 import { Pool } from "pg";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,


### PR DESCRIPTION
## Summary
- mark annual plan export, data, and save routes as dynamic Node.js runtime with no cache
- wrap annual plan export query in try/catch to avoid build-time DB errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint init prompt)*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68be7da5490883218e478370f1679cbf