### PR TITLE
Add web channel audit diagnostics and reclassification pages

### DIFF
--- a/app/api/diag/kpi-web-audit-reclass/route.ts
+++ b/app/api/diag/kpi-web-audit-reclass/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+function fyNow() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1));
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1));
+  const months: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
+    months.push(d.toISOString().slice(0, 10));
+  }
+  return { startISO: start.toISOString().slice(0,10), endISO: end.toISOString().slice(0,10), months, label:`FY${fyStartYear+1-2000}` };
+}
+function ym(s:string){return s.slice(0,7);} 
+function toNum(v:any){return typeof v==="string"?Number(v):(v??0);} 
+
+function reclass(norm: string): "WEB"|"WHOLESALE"|"STORE"|"SHOKU"|"OTHER" {
+  const n = (norm || "").toUpperCase();
+  if (n === "WEB" || n === "WHOLESALE" || n === "STORE" || n === "SHOKU") return n as any;
+  // WEB 推測
+  if (/(^|[^A-Z])(WEB|EC|NET|ONLINE|ＷＥＢ|ＥＣ)([^A-Z]|$)/.test(n)) return "WEB";
+  return "OTHER";
+}
+
+export async function GET() {
+  try {
+    const { startISO, endISO, months, label } = fyNow();
+    const sql = `
+      select date_trunc('month', fiscal_month)::date as m,
+             upper(btrim(channel_code)) as norm_channel,
+             sum(actual_amount_yen) as amt
+      from kpi.kpi_sales_monthly_computed_v2
+      where fiscal_month >= $1 and fiscal_month < $2
+      group by 1,2
+      order by 1,2
+    `;
+    const { rows } = await pool.query(sql, [startISO, endISO]);
+
+    const pivot: Record<string, Record<string, number>> = {};
+    const perMonthTotal: Record<string, number> = {};
+    for (const r of rows as any[]) {
+      const m = ym(r.m.toISOString().slice(0,10));
+      const klass = reclass(r.norm_channel || "");
+      const amt = toNum(r.amt);
+      const row = (pivot[m] ||= {});
+      row[klass] = (row[klass] ?? 0) + amt;
+      perMonthTotal[m] = (perMonthTotal[m] ?? 0) + amt;
+    }
+
+    return NextResponse.json({
+      ok:true,
+      fy:{ label, startISO, endISO },
+      months: months.map(ym),
+      pivot,
+      perMonthTotal
+    });
+  } catch (e:any) {
+    return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status:500 });
+  }
+}

--- a/app/api/diag/kpi-web-audit.csv/route.ts
+++ b/app/api/diag/kpi-web-audit.csv/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+function fyNow() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1));
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1));
+  const months: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
+    months.push(d.toISOString().slice(0, 10));
+  }
+  return { startISO: start.toISOString().slice(0,10), endISO: end.toISOString().slice(0,10), months };
+}
+function ym(s:string){return s.slice(0,7);} 
+function csv(s:string){return /[",\n]/.test(s)?`"${s.replace(/"/g,'""')}"`:s;}
+
+export async function GET() {
+  const { startISO, endISO, months } = fyNow();
+  const sql = `
+    with base as (
+      select date_trunc('month', fiscal_month)::date as m,
+             channel_code as raw_channel,
+             upper(btrim(channel_code)) as norm_channel,
+             sum(actual_amount_yen) as amt
+      from kpi.kpi_sales_monthly_computed_v2
+      where fiscal_month >= $1 and fiscal_month < $2
+      group by 1,2,3
+    )
+    select * from base order by m asc, norm_channel asc
+  `;
+  const { rows } = await pool.query(sql, [startISO, endISO]);
+
+  const set = new Set<string>();
+  rows.forEach(r => set.add(r.norm_channel||"(null)"));
+  const chs = Array.from(set).sort();
+
+  const header = ["month", ...chs, "TOTAL"].join(",");
+  const map = new Map<string, Record<string, number>>();
+  months.map(ym).forEach(m => map.set(m, {}));
+  rows.forEach((r:any)=>{
+    const m = ym(r.m.toISOString().slice(0,10));
+    const ch = r.norm_channel || "(null)";
+    const v = Number(r.amt)||0;
+    const row = map.get(m)!;
+    row[ch] = (row[ch] ?? 0) + v;
+    row["TOTAL"] = (row["TOTAL"] ?? 0) + v;
+  });
+
+  const lines = [header];
+  months.map(ym).forEach(m=>{
+    const row = map.get(m)!;
+    lines.push([m, ...chs.map(c=>String(row[c]??0)), String(row["TOTAL"]??0)].join(","));
+  });
+
+  const csvText = lines.join("\n");
+  return new NextResponse(csvText, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="kpi_web_audit.csv"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/api/diag/kpi-web-audit/route.ts
+++ b/app/api/diag/kpi-web-audit/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+// 会計年度=8月開始
+function fyNow() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1));
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1));
+  const months: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
+    months.push(d.toISOString().slice(0, 10));
+  }
+  const label = `FY${fyStartYear + 1 - 2000}`;
+  return { startISO: start.toISOString().slice(0,10), endISO: end.toISOString().slice(0,10), months, label };
+}
+
+function ym(s: string){ return s.slice(0,7); }
+function toNum(v:any){ return typeof v==="string" ? Number(v) : (v ?? 0); }
+
+export async function GET() {
+  try {
+    const { startISO, endISO, months, label } = fyNow();
+
+    // 正規チャネル定義
+    const CANON = ["WEB","WHOLESALE","STORE","SHOKU"];
+
+    // 月×チャネル（raw / 正規化視点の両方）を集計
+    const sql = `
+      with base as (
+        select
+          date_trunc('month', fiscal_month)::date as m,
+          channel_code as raw_channel,
+          upper(btrim(channel_code)) as norm_channel,
+          sum(actual_amount_yen) as amt
+        from kpi.kpi_sales_monthly_computed_v2
+        where fiscal_month >= $1 and fiscal_month < $2
+        group by 1,2,3
+      )
+      select * from base
+      order by m asc, norm_channel asc
+    `;
+    const { rows } = await pool.query(sql, [startISO, endISO]);
+
+    // pivot: { ym: { channel: amt, TOTAL } }
+    const pivot: Record<string, Record<string, number>> = {};
+    const perMonthTotal: Record<string, number> = {};
+    const unknownByMonth: Record<string, Array<{raw:string; norm:string; amt:number}>> = {};
+    const channelStats: Record<string, {sum:number; first?:string; last?:string; rawVariants:Set<string>}> = {};
+
+    for (const r of rows as any[]) {
+      const key = ym(r.m.toISOString().slice(0,10));
+      const ch = r.norm_channel || "(null)";
+      const amt = toNum(r.amt);
+
+      if (!pivot[key]) pivot[key] = {};
+      pivot[key][ch] = (pivot[key][ch] ?? 0) + amt;
+      perMonthTotal[key] = (perMonthTotal[key] ?? 0) + amt;
+
+      if (!channelStats[ch]) channelStats[ch] = { sum:0, rawVariants:new Set<string>() };
+      channelStats[ch].sum += amt;
+      channelStats[ch].first = channelStats[ch].first ?? key;
+      channelStats[ch].last = key;
+      if (r.raw_channel != null) channelStats[ch].rawVariants.add(String(r.raw_channel));
+
+      if (!CANON.includes(ch)) {
+        (unknownByMonth[key] ||= []).push({ raw: String(r.raw_channel), norm: ch, amt });
+      }
+    }
+
+    // WEB=0で total>0 の月
+    const webZeroMonths: string[] = [];
+    for (const m of months.map(ym)) {
+      const webAmt = pivot[m]?.["WEB"] ?? 0;
+      const tot = perMonthTotal[m] ?? 0;
+      if (webAmt === 0 && tot > 0) webZeroMonths.push(m);
+    }
+
+    // 返却
+    return NextResponse.json({
+      ok: true,
+      fy: { label, startISO, endISO },
+      months: months.map(ym),
+      pivot,
+      perMonthTotal,
+      webZeroMonths,
+      canon: CANON,
+      channelStats: Object.entries(channelStats).map(([k,v])=>({
+        norm: k,
+        sum: v.sum,
+        first: v.first,
+        last: v.last,
+        rawVariants: Array.from(v.rawVariants)
+      })),
+      // 月別の未知チャネル（WEBが0の月を優先して見る）
+      unknownByMonth,
+    });
+  } catch (e:any) {
+    return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status:500 });
+  }
+}

--- a/app/diag/kpi-web-audit-reclass/page.tsx
+++ b/app/diag/kpi-web-audit-reclass/page.tsx
@@ -1,0 +1,53 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function JPY(n:number){return new Intl.NumberFormat("ja-JP",{style:"currency",currency:"JPY",maximumFractionDigits:0}).format(n||0);}
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/diag/kpi-web-audit-reclass`, { cache:"no-store" });
+  const data = await res.json();
+
+  if (!data?.ok) {
+    return <main className="p-6"><h1 className="text-xl font-semibold">WEB仮再分類（同義語集計）</h1><pre className="mt-4 text-xs">{JSON.stringify(data,null,2)}</pre></main>
+  }
+
+  const months: string[] = data.months;
+  const channels = ["WEB","WHOLESALE","STORE","SHOKU","OTHER"];
+
+  return (
+    <main className="p-6 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">WEB仮再分類（{data.fy.label}）</h1>
+        <p className="text-sm text-neutral-500">rule: UPPER(TRIM(channel_code)) に対して /WEB|EC|NET|ONLINE/ を含むものは WEB とみなす</p>
+      </header>
+
+      <section className="space-y-2">
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[1000px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[120px]">month</th>
+                {channels.map(c => <th key={c} className="px-3 py-2 text-right">{c}</th>)}
+                <th className="px-3 py-2 text-right">TOTAL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {months.map(m=>{
+                const row = data.pivot[m] || {};
+                const total = data.perMonthTotal[m] || 0;
+                return (
+                  <tr key={m} className="border-t">
+                    <td className="px-3 py-2 font-medium">{m}</td>
+                    {channels.map(c => <td key={`${m}-${c}`} className="px-3 py-2 text-right">{JPY(row[c]||0)}</td>)}
+                    <td className="px-3 py-2 text-right font-semibold">{JPY(total)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/diag/kpi-web-audit/page.tsx
+++ b/app/diag/kpi-web-audit/page.tsx
@@ -1,0 +1,128 @@
+// 可視化: 月×チャネルPivot + 警告一覧
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function JPY(n:number){return new Intl.NumberFormat("ja-JP",{style:"currency",currency:"JPY",maximumFractionDigits:0}).format(n||0);}
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/diag/kpi-web-audit`, { cache: "no-store" });
+  const data = await res.json();
+
+  if (!data?.ok) {
+    return <main className="p-6"><h1 className="text-xl font-semibold">WEB欠損診断</h1><pre className="mt-4 text-xs">{JSON.stringify(data,null,2)}</pre></main>;
+  }
+
+  const months: string[] = data.months;
+  const channels = Array.from(new Set(Object.values(data.pivot).flatMap((r:any)=>Object.keys(r)))).sort();
+  const warnMonths: string[] = data.webZeroMonths;
+
+  return (
+    <main className="p-6 space-y-8">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">WEB欠損診断（{data.fy.label}）</h1>
+        <p className="text-sm text-neutral-500">
+          Source: <code>kpi.kpi_sales_monthly_computed_v2</code>（raw集計 / 正規化=UPPER(TRIM(channel_code)））
+        </p>
+        <div className="text-sm">
+          WEBが0かつ月合計 &gt; 0 の月:{" "}
+          {warnMonths.length ? warnMonths.join(", ") : "なし"}
+        </div>
+        <div>
+          <a className="text-sm underline" href="/api/diag/kpi-web-audit.csv">CSVダウンロード</a>
+        </div>
+      </header>
+
+      {/* Pivot */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">Pivot（月 × チャネル（金額））</h2>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[1000px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[120px]">month</th>
+                {channels.map((c)=>(
+                  <th key={c} className="px-3 py-2 text-right">{c}</th>
+                ))}
+                <th className="px-3 py-2 text-right">TOTAL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {months.map((m)=> {
+                const row = data.pivot[m] || {};
+                const total = data.perMonthTotal[m] || 0;
+                return (
+                  <tr key={m} className={`border-t ${data.webZeroMonths.includes(m) ? "bg-yellow-50" : ""}`}>
+                    <td className="px-3 py-2 font-medium">{m}</td>
+                    {channels.map((c)=>(
+                      <td key={`${m}-${c}`} className="px-3 py-2 text-right">{JPY(row[c] || 0)}</td>
+                    ))}
+                    <td className="px-3 py-2 text-right font-semibold">{JPY(total)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* 未知チャネル一覧 */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">未知チャネル（正規 {data.canon.join(", ")} 以外）</h2>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[720px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[120px]">month</th>
+                <th className="px-3 py-2 text-left">raw_channel</th>
+                <th className="px-3 py-2 text-left">norm_channel</th>
+                <th className="px-3 py-2 text-right">amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries<any[]>(data.unknownByMonth).flatMap(([m,list]) =>
+                list.map((r,i)=>(
+                  <tr key={`${m}-${i}`} className={`border-t ${data.webZeroMonths.includes(m) ? "bg-yellow-50" : ""}`}>
+                    <td className="px-3 py-2">{m}</td>
+                    <td className="px-3 py-2">{r.raw}</td>
+                    <td className="px-3 py-2">{r.norm}</td>
+                    <td className="px-3 py-2 text-right">{JPY(r.amt)}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* チャネル統計 */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">チャネル統計（正規化単位）</h2>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[720px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[160px]">norm_channel</th>
+                <th className="px-3 py-2 text-left">raw_variants</th>
+                <th className="px-3 py-2 text-left">first</th>
+                <th className="px-3 py-2 text-left">last</th>
+                <th className="px-3 py-2 text-right">sum</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.channelStats.sort((a:any,b:any)=>b.sum-a.sum).map((r:any,i:number)=>(
+                <tr key={i} className="border-t">
+                  <td className="px-3 py-2">{r.norm}</td>
+                  <td className="px-3 py-2">{(r.rawVariants||[]).join(", ")}</td>
+                  <td className="px-3 py-2">{r.first}</td>
+                  <td className="px-3 py-2">{r.last}</td>
+                  <td className="px-3 py-2 text-right">{JPY(r.sum)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add API to pivot fiscal-year sales by channel and flag months with zero WEB sales
- expose CSV download and diagnostic UI with unknown channel warnings
- provide reclassification endpoint and page consolidating WEB synonyms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68be8816d70083218b3bc899168b5790