### PR TITLE
Add KPI final audit and diff diagnostics

### DIFF
--- a/app/api/diag/kpi-diff-final-vs-computed/route.ts
+++ b/app/api/diag/kpi-diff-final-vs-computed/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+function fyNow(){
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1));
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1));
+  const months: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
+    months.push(d.toISOString().slice(0, 10));
+  }
+  return { startISO:start.toISOString().slice(0,10), endISO:end.toISOString().slice(0,10), months, label:`FY${fyStartYear+1-2000}`};
+}
+const ym = (s:string)=>s.slice(0,7);
+const toNum = (v:any)=> typeof v==="string" ? Number(v) : (v ?? 0);
+const CANON = ["WEB","WHOLESALE","STORE","SHOKU"];
+function klass(norm:string){ const n=(norm||"").toUpperCase().trim(); return CANON.includes(n)?n:"OTHER"; }
+
+export async function GET(){
+  try{
+    const { startISO, endISO, months, label } = fyNow();
+
+    const sql = (table:string)=>`
+      select date_trunc('month', fiscal_month)::date as m,
+             upper(btrim(channel_code)) as norm_channel,
+             sum(actual_amount_yen) as amt
+      from ${table}
+      where fiscal_month >= $1 and fiscal_month < $2
+      group by 1,2
+      order by 1,2
+    `;
+
+    const [fin, comp] = await Promise.all([
+      pool.query(sql("kpi.kpi_sales_monthly_final_v1"), [startISO, endISO]),
+      pool.query(sql("kpi.kpi_sales_monthly_computed_v2"), [startISO, endISO]),
+    ]);
+
+    // pivot 作成（final / computed）
+    const makePivot = (rows:any[])=>{
+      const p: Record<string, Record<string, number>> = {};
+      for(const r of rows){
+        const m = ym(r.m.toISOString().slice(0,10));
+        const ch = klass(r.norm_channel);
+        const amt = toNum(r.amt);
+        (p[m] ||= {})[ch] = (p[m]?.[ch] ?? 0) + amt;
+      }
+      return p;
+    };
+    const pf = makePivot(fin.rows as any[]);
+    const pc = makePivot(comp.rows as any[]);
+
+    // delta = final - computed
+    const delta: Record<string, Record<string, number>> = {};
+    const monthsYM = months.map(ym);
+    const allCh = ["WEB","WHOLESALE","STORE","SHOKU","OTHER"];
+
+    for(const m of monthsYM){
+      delta[m] = {};
+      for(const ch of allCh){
+        const v = (pf[m]?.[ch] ?? 0) - (pc[m]?.[ch] ?? 0);
+        if (v !== 0) delta[m][ch] = v;
+      }
+      const totV = (Object.values(pf[m]||{}).reduce((s,n)=>s+n,0)) - (Object.values(pc[m]||{}).reduce((s,n)=>s+n,0));
+      if (totV !== 0) delta[m]["TOTAL"] = totV;
+    }
+
+    return NextResponse.json({ ok:true, fy:{label}, months: monthsYM, final: pf, computed: pc, delta });
+  }catch(e:any){
+    return NextResponse.json({ ok:false, error:e?.message || String(e) }, { status:500 });
+  }
+}

--- a/app/api/diag/kpi-final-audit/route.ts
+++ b/app/api/diag/kpi-final-audit/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+// 会計年度=8月開始
+function fyNow() {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1));
+  const end = new Date(Date.UTC(fyStartYear + 1, 7, 1));
+  const months: string[] = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, 1));
+    months.push(d.toISOString().slice(0, 10));
+  }
+  return { startISO: start.toISOString().slice(0,10), endISO: end.toISOString().slice(0,10), months, label: `FY${fyStartYear + 1 - 2000}` };
+}
+const ym = (s:string)=>s.slice(0,7);
+const toNum = (v:any)=> typeof v==="string" ? Number(v) : (v ?? 0);
+
+export async function GET() {
+  try {
+    const { startISO, endISO, months, label } = fyNow();
+
+    const CANON = ["WEB","WHOLESALE","STORE","SHOKU"];
+
+    // final_v1 をそのまま集計（表記ゆれ検知のため raw と UPPER(TRIM) 両方持つ）
+    const sql = `
+      with base as (
+        select
+          date_trunc('month', fiscal_month)::date as m,
+          channel_code as raw_channel,
+          upper(btrim(channel_code)) as norm_channel,
+          sum(actual_amount_yen) as amt
+        from kpi.kpi_sales_monthly_final_v1
+        where fiscal_month >= $1 and fiscal_month < $2
+        group by 1,2,3
+      )
+      select * from base order by m asc, norm_channel asc
+    `;
+    const { rows } = await pool.query(sql, [startISO, endISO]);
+
+    const pivot: Record<string, Record<string, number>> = {};
+    const perMonthTotal: Record<string, number> = {};
+    const unknownByMonth: Record<string, Array<{raw:string; norm:string; amt:number}>> = {};
+    const channelStats: Record<string, {sum:number; first?:string; last?:string; raw:Set<string>}> = {};
+
+    for (const r of rows as any[]) {
+      const m = ym(r.m.toISOString().slice(0,10));
+      const norm = r.norm_channel || "(null)";
+      const raw = String(r.raw_channel ?? "");
+      const amt = toNum(r.amt);
+
+      (pivot[m] ||= {})[norm] = (pivot[m]?.[norm] ?? 0) + amt;
+      perMonthTotal[m] = (perMonthTotal[m] ?? 0) + amt;
+
+      (channelStats[norm] ||= {sum:0, raw:new Set<string>()}).sum += amt;
+      channelStats[norm].first = channelStats[norm].first ?? m;
+      channelStats[norm].last = m;
+      if (raw) channelStats[norm].raw.add(raw);
+
+      if (!CANON.includes(norm)) {
+        (unknownByMonth[m] ||= []).push({ raw, norm, amt });
+      }
+    }
+
+    const webZeroMonths: string[] = [];
+    months.map(ym).forEach(m=>{
+      const web = pivot[m]?.["WEB"] ?? 0;
+      const tot = perMonthTotal[m] ?? 0;
+      if (web === 0 && tot > 0) webZeroMonths.push(m);
+    });
+
+    return NextResponse.json({
+      ok:true,
+      fy:{ label, startISO, endISO },
+      months: months.map(ym),
+      pivot,
+      perMonthTotal,
+      webZeroMonths,
+      canon: CANON,
+      channelStats: Object.entries(channelStats).map(([norm,stat])=>({
+        norm, sum: stat.sum, first: stat.first, last: stat.last, rawVariants: Array.from(stat.raw)
+      })),
+      unknownByMonth
+    });
+  } catch (e:any) {
+    return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status:500 });
+  }
+}

--- a/app/diag/kpi-diff-final-vs-computed/page.tsx
+++ b/app/diag/kpi-diff-final-vs-computed/page.tsx
@@ -1,0 +1,58 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const JPY = (n:number)=>new Intl.NumberFormat("ja-JP",{style:"currency",currency:"JPY",maximumFractionDigits:0}).format(n||0);
+const CHS = ["WEB","WHOLESALE","STORE","SHOKU","OTHER"];
+
+export default async function Page(){
+  const res = await fetch(`/api/diag/kpi-diff-final-vs-computed`, { cache:"no-store" });
+  const data = await res.json();
+
+  if(!data?.ok){
+    return <main className="p-6"><h1 className="text-xl font-semibold">final vs computed 差分</h1><pre className="mt-4 text-xs whitespace-pre-wrap">{JSON.stringify(data,null,2)}</pre></main>;
+  }
+
+  const months: string[] = data.months;
+
+  return (
+    <main className="p-6 space-y-8">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">final_v1 vs computed_v2 差分（{data.fy.label}）</h1>
+        <p className="text-sm text-neutral-500">値は <code>final - computed</code>。非0セルのみ表示。</p>
+      </header>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">月次差分（非0のみ）</h2>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[900px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[120px]">month</th>
+                {CHS.map(c=><th key={c} className="px-3 py-2 text-right">{c}</th>)}
+                <th className="px-3 py-2 text-right">TOTAL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {months.map(m=>{
+                const row = data.delta[m] || {};
+                const has = Object.keys(row).length>0;
+                if(!has) return null;
+                return (
+                  <tr key={m} className="border-t">
+                    <td className="px-3 py-2 font-medium">{m}</td>
+                    {CHS.map(c=>{
+                      const v = row[c] ?? 0;
+                      return <td key={`${m}-${c}`} className={`px-3 py-2 text-right ${v!==0?"font-semibold text-red-600":""}`}>{v===0?"—":JPY(v)}</td>;
+                    })}
+                    <td className={`px-3 py-2 text-right ${row.TOTAL? "font-semibold text-red-600":""}`}>{row.TOTAL? JPY(row.TOTAL): "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/diag/kpi-final-audit/page.tsx
+++ b/app/diag/kpi-final-audit/page.tsx
@@ -1,0 +1,85 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const JPY = (n:number)=>new Intl.NumberFormat("ja-JP",{style:"currency",currency:"JPY",maximumFractionDigits:0}).format(n||0);
+
+export default async function Page(){
+  const res = await fetch(`/api/diag/kpi-final-audit`, { cache:"no-store" });
+  const data = await res.json();
+
+  if(!data?.ok){
+    return <main className="p-6"><h1 className="text-xl font-semibold">final_v1 監査</h1><pre className="mt-4 text-xs whitespace-pre-wrap">{JSON.stringify(data,null,2)}</pre></main>;
+  }
+  const months: string[] = data.months;
+  const channels = Array.from(new Set(Object.values(data.pivot).flatMap((r:any)=>Object.keys(r)))).sort();
+
+  return (
+    <main className="p-6 space-y-8">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">final_v1 監査（{data.fy.label}）</h1>
+        <p className="text-sm text-neutral-500">Source: <code>kpi.kpi_sales_monthly_final_v1</code>（UPPER(TRIM(channel_code)) 正規化）</p>
+        <div className="text-sm">WEB=0 &amp; 月合計&gt;0 の月: {data.webZeroMonths.length ? data.webZeroMonths.join(", ") : "なし"}</div>
+      </header>
+
+      {/* Pivot */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">Pivot（月×チャネル）</h2>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[1000px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[120px]">month</th>
+                {channels.map(c=><th key={c} className="px-3 py-2 text-right">{c}</th>)}
+                <th className="px-3 py-2 text-right">TOTAL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {months.map(m=>{
+                const row = data.pivot[m] || {};
+                const tot = data.perMonthTotal[m] || 0;
+                const warn = data.webZeroMonths.includes(m);
+                return (
+                  <tr key={m} className={`border-t ${warn ? "bg-yellow-50" : ""}`}>
+                    <td className="px-3 py-2 font-medium">{m}</td>
+                    {channels.map(c=> <td key={`${m}-${c}`} className="px-3 py-2 text-right">{JPY(row[c]||0)}</td>)}
+                    <td className="px-3 py-2 text-right font-semibold">{JPY(tot)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* 未知チャネル */}
+      <section className="space-y-2">
+        <h2 className="text-lg font-medium">未知チャネル（正規 {data.canon.join(", ")} 以外）</h2>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[720px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[120px]">month</th>
+                <th className="px-3 py-2 text-left">raw_channel</th>
+                <th className="px-3 py-2 text-left">norm_channel</th>
+                <th className="px-3 py-2 text-right">amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries<any[]>(data.unknownByMonth).flatMap(([m,list]) =>
+                list.map((r,i)=>(
+                  <tr key={`${m}-${i}`} className={`border-t ${data.webZeroMonths.includes(m) ? "bg-yellow-50" : ""}`}>
+                    <td className="px-3 py-2">{m}</td>
+                    <td className="px-3 py-2">{r.raw}</td>
+                    <td className="px-3 py-2">{r.norm}</td>
+                    <td className="px-3 py-2 text-right">{JPY(r.amt)}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add API endpoint to audit `kpi_sales_monthly_final_v1` for missing WEB channel months, unknown channels, and per-channel stats
- add UI page to view final_v1 audit results
- add API and UI to compare `final_v1` vs `computed_v2` sales with per-month channel deltas

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68be94f1041083218f41bf9bbc8262aa