### PR TITLE
feat: add diagnostic page for final vs computed KPI diff

### DIFF
--- a/app/diag/kpi-diff-final-vs-computed/page.tsx
+++ b/app/diag/kpi-diff-final-vs-computed/page.tsx
@@ -10,7 +10,12 @@ export default async function Page(){
   const data = await res.json();
 
   if(!data?.ok){
-    return <main className="p-6"><h1 className="text-xl font-semibold">final vs computed 差分</h1><pre className="mt-4 text-xs whitespace-pre-wrap">{JSON.stringify(data,null,2)}</pre></main>;
+    return (
+      <main className="p-6">
+        <h1 className="text-xl font-semibold">final vs computed 差分</h1>
+        <pre className="mt-4 text-xs whitespace-pre-wrap">{JSON.stringify(data,null,2)}</pre>
+      </main>
+    );
   }
 
   const months: string[] = data.months;
@@ -19,11 +24,13 @@ export default async function Page(){
     <main className="p-6 space-y-8">
       <header className="space-y-1">
         <h1 className="text-2xl font-semibold">final_v1 vs computed_v2 差分（{data.fy.label}）</h1>
-        <p className="text-sm text-neutral-500">値は <code>final - computed</code>。非0セルのみ表示。</p>
+        <p className="text-sm text-neutral-500">
+          値は <code>final - computed</code>。≠0 のセルのみ強調表示。
+        </p>
       </header>
 
       <section className="space-y-2">
-        <h2 className="text-lg font-medium">月次差分（非0のみ）</h2>
+        <h2 className="text-lg font-medium">月次差分（非0のみ強調）</h2>
         <div className="overflow-x-auto rounded-2xl border">
           <table className="min-w-[900px] w-full text-sm">
             <thead className="bg-neutral-50">
@@ -37,13 +44,20 @@ export default async function Page(){
               {months.map(m=>{
                 const row = data.delta[m] || {};
                 const has = Object.keys(row).length>0;
-                if(!has) return null;
+                if(!has) return (
+                  <tr key={m} className="border-t">
+                    <td className="px-3 py-2 font-medium">{m}</td>
+                    {CHS.map(c=> <td key={`${m}-${c}`} className="px-3 py-2 text-right">—</td>)}
+                    <td className="px-3 py-2 text-right">—</td>
+                  </tr>
+                );
                 return (
                   <tr key={m} className="border-t">
                     <td className="px-3 py-2 font-medium">{m}</td>
                     {CHS.map(c=>{
                       const v = row[c] ?? 0;
-                      return <td key={`${m}-${c}`} className={`px-3 py-2 text-right ${v!==0?"font-semibold text-red-600":""}`}>{v===0?"—":JPY(v)}</td>;
+                      const hit = v !== 0;
+                      return <td key={`${m}-${c}`} className={`px-3 py-2 text-right ${hit?"font-semibold text-red-600":""}`}>{hit? JPY(v): "—"}</td>;
                     })}
                     <td className={`px-3 py-2 text-right ${row.TOTAL? "font-semibold text-red-600":""}`}>{row.TOTAL? JPY(row.TOTAL): "—"}</td>
                   </tr>
@@ -56,3 +70,4 @@ export default async function Page(){
     </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- add Node runtime page to view KPI final vs computed diff

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint config)
- `npm run build` (interrupted during Next.js build)


------
https://chatgpt.com/codex/tasks/task_e_68be9bed7bac832189bea49437793b0e