### PR TITLE
Add diagnostic DB smoke and diff pages

### DIFF
--- a/app/diag/_db-smoke/page.tsx
+++ b/app/diag/_db-smoke/page.tsx
@@ -1,0 +1,89 @@
+// DB接続・クエリのスモークテスト（エラーはそのまま表示）
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+function JPY(n:number){return new Intl.NumberFormat("ja-JP",{style:"currency",currency:"JPY",maximumFractionDigits:0}).format(n||0);}
+
+async function run() {
+  const info = await pool.query(`
+    select current_database() as db, current_user as usr, version() as ver
+  `);
+
+  // 直近FYレンジ（8月開始）
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1)).toISOString().slice(0,10);
+  const end   = new Date(Date.UTC(fyStartYear+1, 7, 1)).toISOString().slice(0,10);
+
+  // final/computed を最小集計で確認
+  const q = (table:string)=>pool.query(`
+    select upper(btrim(channel_code)) as ch, sum(actual_amount_yen)::numeric as amt
+    from ${table}
+    where fiscal_month >= $1 and fiscal_month < $2
+    group by 1
+    order by 1
+  `,[start, end]);
+
+  const [fin, comp] = await Promise.all([
+    q("kpi.kpi_sales_monthly_final_v1"),
+    q("kpi.kpi_sales_monthly_computed_v2")
+  ]);
+
+  return {
+    ok: true,
+    env: {
+      db: info.rows?.[0]?.db,
+      usr: info.rows?.[0]?.usr,
+      ver: info.rows?.[0]?.ver?.split("\n")?.[0],
+      range: { start, end }
+    },
+    final: fin.rows,
+    computed: comp.rows,
+  };
+}
+
+export default async function Page(){
+  try{
+    const data = await run();
+    return (
+      <main className="p-6 space-y-6">
+        <h1 className="text-2xl font-semibold">DB Smoke</h1>
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">環境</h2>
+          <pre className="text-xs whitespace-pre-wrap">{JSON.stringify(data.env,null,2)}</pre>
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">final_v1 合計（FYレンジ）</h2>
+          <ul className="text-sm">
+            {data.final.map((r:any,i:number)=>(<li key={i}>{r.ch}: {JPY(Number(r.amt)||0)}</li>))}
+          </ul>
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">computed_v2 合計（FYレンジ）</h2>
+          <ul className="text-sm">
+            {data.computed.map((r:any,i:number)=>(<li key={i}>{r.ch}: {JPY(Number(r.amt)||0)}</li>))}
+          </ul>
+        </section>
+      </main>
+    );
+  }catch(e:any){
+    return (
+      <main className="p-6">
+        <h1 className="text-2xl font-semibold">DB Smoke</h1>
+        <p className="text-sm text-red-600">エラー内容：</p>
+        <pre className="mt-4 text-xs whitespace-pre-wrap">{e?.message || String(e)}</pre>
+      </main>
+    );
+  }
+}
+

--- a/app/diag/kpi-diff-min/page.tsx
+++ b/app/diag/kpi-diff-min/page.tsx
@@ -1,0 +1,111 @@
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const JPY = (n:number)=>new Intl.NumberFormat("ja-JP",{style:"currency",currency:"JPY",maximumFractionDigits:0}).format(n||0);
+const CHS = ["WEB","WHOLESALE","STORE","SHOKU","OTHER"] as const;
+const CANON = new Set(CHS);
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false }});
+
+const ym = (s:string)=>s.slice(0,7);
+const toNum = (v:any)=> typeof v==="string" ? Number(v) : (v ?? 0);
+const klass = (norm:string)=> {
+  const n = (norm||"").toUpperCase().trim();
+  return CANON.has(n as any) ? (n as typeof CHS[number]) : "OTHER";
+};
+
+function fyNow(){
+  const now=new Date(); const y=now.getUTCFullYear(); const m=now.getUTCMonth()+1;
+  const fyStartYear = m>=8 ? y : y-1;
+  const start = new Date(Date.UTC(fyStartYear,7,1));
+  const end   = new Date(Date.UTC(fyStartYear+1,7,1));
+  const months:string[]=[]; for(let i=0;i<12;i++){ const d=new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth()+i,1)); months.push(d.toISOString().slice(0,10)); }
+  return { fy:`FY${fyStartYear+1-2000}`, startISO:start.toISOString().slice(0,10), endISO:end.toISOString().slice(0,10), monthsYM: months.map(ym) };
+}
+
+async function pivot(table:string, a:string, b:string){
+  const sql = `
+    select date_trunc('month', fiscal_month)::date as m,
+           upper(btrim(channel_code)) as norm_channel,
+           sum(actual_amount_yen) as amt
+    from ${table}
+    where fiscal_month >= $1 and fiscal_month < $2
+    group by 1,2
+  `;
+  const { rows } = await pool.query(sql,[a,b]);
+  const p:Record<string,Record<string,number>> = {};
+  for(const r of rows as any[]){
+    const k = ym(r.m.toISOString().slice(0,10));
+    const ch = klass(r.norm_channel);
+    const v = toNum(r.amt);
+    (p[k] ||= {}); p[k][ch] = (p[k][ch] ?? 0) + v;
+  }
+  return p;
+}
+
+export default async function Page(){
+  try{
+    const { fy, startISO, endISO, monthsYM } = fyNow();
+    const [pf, pc] = await Promise.all([
+      pivot("kpi.kpi_sales_monthly_final_v1", startISO, endISO),
+      pivot("kpi.kpi_sales_monthly_computed_v2", startISO, endISO),
+    ]);
+
+    // delta
+    const delta:Record<string,Record<string,number>> = {};
+    for(const m of monthsYM){
+      const row:Record<string,number> = {};
+      for(const ch of CHS){
+        const v = (pf[m]?.[ch] ?? 0) - (pc[m]?.[ch] ?? 0);
+        if(v!==0) row[ch]=v;
+      }
+      const tf = Object.values(pf[m]||{}).reduce((s,n)=>s+n,0);
+      const tc = Object.values(pc[m]||{}).reduce((s,n)=>s+n,0);
+      if(tf!==tc) row["TOTAL"]=tf-tc;
+      delta[m]=row;
+    }
+
+    return (
+      <main className="p-6 space-y-6">
+        <h1 className="text-2xl font-semibold">final vs computed 差分（{fy}）</h1>
+        <div className="overflow-x-auto rounded-2xl border">
+          <table className="min-w-[900px] w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left w-[120px]">month</th>
+                {CHS.map(c=><th key={c} className="px-3 py-2 text-right">{c}</th>)}
+                <th className="px-3 py-2 text-right">TOTAL</th>
+              </tr>
+            </thead>
+            <tbody>
+              {monthsYM.map(m=>{
+                const row = delta[m] || {};
+                return (
+                  <tr key={m} className="border-t">
+                    <td className="px-3 py-2 font-medium">{m}</td>
+                    {CHS.map(c=>{
+                      const v = row[c as any] ?? 0;
+                      return <td key={`${m}-${c}`} className={`px-3 py-2 text-right ${v!==0?"font-semibold text-red-600":""}`}>{v!==0? JPY(v): "—"}</td>;
+                    })}
+                    <td className={`px-3 py-2 text-right ${row["TOTAL"]? "font-semibold text-red-600":""}`}>{row["TOTAL"]? JPY(row["TOTAL"]): "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </main>
+    );
+  }catch(e:any){
+    return (
+      <main className="p-6">
+        <h1 className="text-2xl font-semibold">final vs computed 差分</h1>
+        <p className="text-sm text-red-600">エラー：{e?.message || String(e)}</p>
+      </main>
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add DB smoke test page to verify connection and channel totals
- add direct database diff page comparing final vs computed monthly KPIs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe140187083219c68a3a416774844