### PR TITLE
Expose diagnostic probe and db smoke routes without underscores

### DIFF
--- a/app/api/diag/probe/route.ts
+++ b/app/api/diag/probe/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server";
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+type Check = { name: string; ok: boolean; info?: any; error?: string };
+
+async function run(): Promise<{ ok: boolean; checks: Check[]; }> {
+  const checks: Check[] = [];
+
+  // 0) env
+  try {
+    const url = process.env.DATABASE_URL || "";
+    checks.push({ name: "env.DATABASE_URL", ok: !!url, info: url ? `***${url.slice(-12)}` : "EMPTY" });
+  } catch (e:any) {
+    checks.push({ name: "env.DATABASE_URL", ok: false, error: e?.message || String(e) });
+  }
+
+  // 1) connect
+  try {
+    const c = await pool.connect(); c.release();
+    checks.push({ name: "pg.connect", ok: true });
+  } catch (e:any) {
+    checks.push({ name: "pg.connect", ok: false, error: e?.message || String(e) });
+    return { ok:false, checks };
+  }
+
+  // 2) info
+  try {
+    const r = await pool.query(`select current_database() db, current_user usr, version() ver, now() now_utc`);
+    checks.push({ name: "pg.info", ok: true, info: { db:r.rows[0].db, usr:r.rows[0].usr, ver:String(r.rows[0].ver).split("\n")[0], now_utc:r.rows[0].now_utc }});
+  } catch (e:any) {
+    checks.push({ name: "pg.info", ok: false, error: e?.message || String(e) });
+  }
+
+  // 3) FY range (8月開始)
+  const now = new Date();
+  const y = now.getUTCFullYear(); const m = now.getUTCMonth()+1;
+  const fyStartYear = m>=8 ? y : y-1;
+  const startISO = new Date(Date.UTC(fyStartYear,7,1)).toISOString().slice(0,10);
+  const endISO   = new Date(Date.UTC(fyStartYear+1,7,1)).toISOString().slice(0,10);
+  checks.push({ name:"fy.range", ok:true, info:{ startISO, endISO, label:`FY${fyStartYear+1-2000}` }});
+
+  // 4) tables exist
+  try {
+    const r = await pool.query(`
+      select table_schema, table_name
+      from information_schema.tables
+      where table_schema='kpi' and table_name in ('kpi_sales_monthly_final_v1','kpi_sales_monthly_computed_v2')
+      order by table_name
+    `);
+    const names = r.rows.map((x:any)=>`${x.table_schema}.${x.table_name}`);
+    checks.push({ name:"tables.exists", ok:names.length===2, info:names });
+    if (names.length<2) return { ok:false, checks };
+  } catch (e:any) {
+    checks.push({ name:"tables.exists", ok:false, error:e?.message || String(e) });
+    return { ok:false, checks };
+  }
+
+  // 5) summaries
+  const mini = async (table:string)=>{
+    const q = `
+      select min(fiscal_month)::date as min_month, max(fiscal_month)::date as max_month, count(*) as rows
+      from ${table} where fiscal_month >= $1 and fiscal_month < $2
+    `;
+    const d = `
+      select upper(btrim(channel_code)) as ch, sum(actual_amount_yen)::numeric as amt
+      from ${table} where fiscal_month >= $1 and fiscal_month < $2
+      group by 1 order by 1
+    `;
+    const [a,b] = await Promise.all([pool.query(q,[startISO,endISO]), pool.query(d,[startISO,endISO])]);
+    return { range:a.rows[0], channels:b.rows };
+  };
+
+  try {
+    const fin = await mini("kpi.kpi_sales_monthly_final_v1");
+    checks.push({ name:"final_v1.summary", ok:true, info:fin });
+  } catch (e:any) {
+    checks.push({ name:"final_v1.summary", ok:false, error:e?.message || String(e) });
+    return { ok:false, checks };
+  }
+
+  try {
+    const comp = await mini("kpi.kpi_sales_monthly_computed_v2");
+    checks.push({ name:"computed_v2.summary", ok:true, info:comp });
+  } catch (e:any) {
+    checks.push({ name:"computed_v2.summary", ok:false, error:e?.message || String(e) });
+    return { ok:false, checks };
+  }
+
+  // 6) FY合計の差（チャネル別）
+  try {
+    const delta = await pool.query(
+      `
+      with f as (
+        select upper(btrim(channel_code)) ch, sum(actual_amount_yen)::numeric amt
+        from kpi.kpi_sales_monthly_final_v1
+        where fiscal_month >= $1 and fiscal_month < $2 group by 1
+      ),
+      c as (
+        select upper(btrim(channel_code)) ch, sum(actual_amount_yen)::numeric amt
+        from kpi.kpi_sales_monthly_computed_v2
+        where fiscal_month >= $1 and fiscal_month < $2 group by 1
+      )
+      select coalesce(f.ch,c.ch) ch, coalesce(f.amt,0) - coalesce(c.amt,0) as delta
+      from f full join c on f.ch=c.ch
+      order by 1
+      `,
+      [startISO, endISO]
+    );
+    checks.push({ name:"fy.delta_by_channel", ok:true, info:delta.rows });
+  } catch (e:any) {
+    checks.push({ name:"fy.delta_by_channel", ok:false, error:e?.message || String(e) });
+  }
+
+  return { ok:true, checks };
+}
+
+export async function GET() {
+  try {
+    const result = await run();
+    return NextResponse.json(result, { status: result.ok ? 200 : 500 });
+  } catch (e:any) {
+    return NextResponse.json({ ok:false, fatal:e?.message || String(e) }, { status:500 });
+  }
+}
+

--- a/app/diag/db-smoke/page.tsx
+++ b/app/diag/db-smoke/page.tsx
@@ -1,0 +1,89 @@
+// DB接続・クエリのスモークテスト（エラーはそのまま表示）
+import { Pool } from "pg";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+function JPY(n:number){return new Intl.NumberFormat("ja-JP",{style:"currency",currency:"JPY",maximumFractionDigits:0}).format(n||0);}
+
+async function run() {
+  const info = await pool.query(`
+    select current_database() as db, current_user as usr, version() as ver
+  `);
+
+  // 直近FYレンジ（8月開始）
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth() + 1;
+  const fyStartYear = m >= 8 ? y : y - 1;
+  const start = new Date(Date.UTC(fyStartYear, 7, 1)).toISOString().slice(0,10);
+  const end   = new Date(Date.UTC(fyStartYear+1, 7, 1)).toISOString().slice(0,10);
+
+  // final/computed を最小集計で確認
+  const q = (table:string)=>pool.query(`
+    select upper(btrim(channel_code)) as ch, sum(actual_amount_yen)::numeric as amt
+    from ${table}
+    where fiscal_month >= $1 and fiscal_month < $2
+    group by 1
+    order by 1
+  `,[start, end]);
+
+  const [fin, comp] = await Promise.all([
+    q("kpi.kpi_sales_monthly_final_v1"),
+    q("kpi.kpi_sales_monthly_computed_v2")
+  ]);
+
+  return {
+    ok: true,
+    env: {
+      db: info.rows?.[0]?.db,
+      usr: info.rows?.[0]?.usr,
+      ver: info.rows?.[0]?.ver?.split("\n")?.[0],
+      range: { start, end }
+    },
+    final: fin.rows,
+    computed: comp.rows,
+  };
+}
+
+export default async function Page(){
+  try{
+    const data = await run();
+    return (
+      <main className="p-6 space-y-6">
+        <h1 className="text-2xl font-semibold">DB Smoke</h1>
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">環境</h2>
+          <pre className="text-xs whitespace-pre-wrap">{JSON.stringify(data.env,null,2)}</pre>
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">final_v1 合計（FYレンジ）</h2>
+          <ul className="text-sm">
+            {data.final.map((r:any,i:number)=>(<li key={i}>{r.ch}: {JPY(Number(r.amt)||0)}</li>))}
+          </ul>
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-lg font-medium">computed_v2 合計（FYレンジ）</h2>
+          <ul className="text-sm">
+            {data.computed.map((r:any,i:number)=>(<li key={i}>{r.ch}: {JPY(Number(r.amt)||0)}</li>))}
+          </ul>
+        </section>
+      </main>
+    );
+  }catch(e:any){
+    return (
+      <main className="p-6">
+        <h1 className="text-2xl font-semibold">DB Smoke</h1>
+        <p className="text-sm text-red-600">エラー内容：</p>
+        <pre className="mt-4 text-xs whitespace-pre-wrap">{e?.message || String(e)}</pre>
+      </main>
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add public diagnostic probe endpoint for database checks
- duplicate db-smoke page without underscore so it is routable

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68c000b64f6c8321906bb27bab96eafa