### PR TITLE
feat: add manual KPI entry API and page

### DIFF
--- a/app/kpi/manual/input/page.tsx
+++ b/app/kpi/manual/input/page.tsx
@@ -1,0 +1,8 @@
+import ManualClient from "../ManualClient";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default function ManualInputPage() {
+  return <ManualClient />;
+}

--- a/sql/20240914_kpi_manual_entries.sql
+++ b/sql/20240914_kpi_manual_entries.sql
@@ -1,0 +1,12 @@
+-- 手入力KPI保存テーブル
+create schema if not exists kpi;
+
+create table if not exists kpi.kpi_manual_entries_v1 (
+  metric text not null,
+  channel_code text not null,
+  month date not null,
+  amount numeric(14,0) not null default 0,
+  note text,
+  updated_at timestamptz not null default now(),
+  primary key (metric, channel_code, month)
+);


### PR DESCRIPTION
## Summary
- add API endpoints to fetch/save/delete manual KPI entries
- expose manual KPI entry UI under `/kpi/manual/input`
- add SQL schema for `kpi_manual_entries_v1`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt, configuration required)

------
https://chatgpt.com/codex/tasks/task_e_68c20b0ef0848321b3e67ea3e16800cc