### PR TITLE
Align KPI monthly dashboard with fiscal year view

### DIFF
--- a/lib/fiscal.ts
+++ b/lib/fiscal.ts
@@ -1,0 +1,60 @@
+import { addMonths, format, isBefore, parseISO, startOfMonth } from "date-fns";
+
+export type FiscalWindow = {
+  start: string;
+  end: string;
+  months: string[];
+  fiscalLabel: string;
+  fiscalStartYear: number;
+  fiscalEndYear: number;
+};
+
+function padMonth(month: number) {
+  return String(month).padStart(2, "0");
+}
+
+/**
+ * 会計年度（8月開始）に基づいた12か月のウィンドウを返す。
+ * latestMonthISO が含まれる直近の「完了済み」FYを対象とする。
+ */
+export function fiscalWindowFromLatest(
+  latestMonthISO: string,
+  fiscalStartMonth = 8
+): FiscalWindow {
+  if (!latestMonthISO) {
+    throw new Error("latestMonthISO is required");
+  }
+
+  const latest = startOfMonth(parseISO(latestMonthISO));
+  if (Number.isNaN(latest.getTime())) {
+    throw new Error(`Invalid latestMonthISO: ${latestMonthISO}`);
+  }
+
+  const latestYear = latest.getUTCFullYear();
+  const pivot = parseISO(`${latestYear}-${padMonth(fiscalStartMonth)}-01`);
+  const fiscalEndYear = isBefore(latest, pivot) ? latestYear - 1 : latestYear;
+  const fiscalStartYear = fiscalEndYear - 1;
+
+  const start = parseISO(`${fiscalStartYear}-${padMonth(fiscalStartMonth)}-01`);
+  const months: string[] = [];
+  for (let i = 0; i < 12; i += 1) {
+    const m = addMonths(start, i);
+    months.push(format(m, "yyyy-MM-01"));
+  }
+  const end = addMonths(start, 11);
+
+  if (months.length !== 12) {
+    throw new Error(`Fiscal window must be 12 months but got ${months.length}`);
+  }
+
+  const fiscalLabel = `FY${String(fiscalEndYear).slice(-2).padStart(2, "0")}`;
+
+  return {
+    start: format(start, "yyyy-MM-01"),
+    end: format(end, "yyyy-MM-01"),
+    months,
+    fiscalLabel,
+    fiscalStartYear,
+    fiscalEndYear,
+  };
+}

--- a/lib/kpiMonthly.ts
+++ b/lib/kpiMonthly.ts
@@ -1,0 +1,52 @@
+export const CHANNELS = ["SHOKU", "STORE", "WEB", "WHOLESALE"] as const;
+
+export type ChannelCode = (typeof CHANNELS)[number];
+
+export type MonthlyRow = {
+  month: string;
+  channel_code: ChannelCode;
+  amount: number;
+};
+
+export type ShapedMonthly = {
+  month: string;
+  byChannel: number[];
+  monthTotal: number;
+};
+
+export function shapeMonthly(rows: MonthlyRow[], months: string[]): ShapedMonthly[] {
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    const key = `${row.month}|${row.channel_code}`;
+    map.set(key, row.amount);
+  }
+
+  return months.map((month) => {
+    const byChannel = CHANNELS.map((channel) => map.get(`${month}|${channel}`) ?? 0);
+    const monthTotal = byChannel.reduce((sum, value) => sum + value, 0);
+    return { month, byChannel, monthTotal };
+  });
+}
+
+export function assertChannelSums(shaped: ShapedMonthly[]) {
+  const diffs = shaped
+    .map((row) => {
+      const sum = row.byChannel.reduce((acc, value) => acc + value, 0);
+      return { month: row.month, sum, total: row.monthTotal, diff: sum - row.monthTotal };
+    })
+    .filter((row) => row.diff !== 0);
+
+  if (diffs.length > 0) {
+    console.error("[KPI] チャネル合計と月合計の不一致", diffs);
+    throw new Error("月別のチャネル合計が月合計と一致していません");
+  }
+
+  console.info("[KPI] チェックOK（チャネル合計＝月合計）");
+}
+
+export function channelTotals(shaped: ShapedMonthly[]) {
+  return CHANNELS.map((channel, idx) => {
+    const total = shaped.reduce((sum, row) => sum + row.byChannel[idx], 0);
+    return { channel, total };
+  });
+}


### PR DESCRIPTION
## Summary
- add fiscal window utility to calculate the latest completed August–July reporting range
- shape and validate monthly KPI data with channel-level totals before rendering
- rebuild the KPI monthly FY page to show a fixed 12-month fiscal year table and surface validation issues

## Testing
- npm run lint *(fails: requires interactive configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca50ad3dd8832193bc3bef4891bd92