### PR TITLE
Ensure KPI dashboard uses unified monthly view

### DIFF
--- a/app/api/kpi/sales/monthly/route.ts
+++ b/app/api/kpi/sales/monthly/route.ts
@@ -12,76 +12,13 @@ const pool = new Pool({
     : undefined,
 });
 
+// unified_v1 ensures we always read the finalised monthly totals per channel.
 const SQL = `
-WITH acts AS (
-  SELECT d.channel_code,
-         date_trunc('month', a.fiscal_month)::date AS month,
-         SUM(a.actual_amount_yen)::bigint AS amt
-  FROM kpi.kpi_sales_actuals_monthly_v1 a
-  JOIN kpi.channel_dim_v1 d ON d.channel_id = a.channel_id
-  WHERE a.fiscal_month IS NOT NULL
-  GROUP BY d.channel_code, date_trunc('month', a.fiscal_month)::date
-),
-ui AS (
-  SELECT 'WHOLESALE'::text AS channel_code,
-         date_trunc('month', u.fiscal_month)::date AS month,
-         SUM(u.actual_amount_yen)::bigint AS amt
-  FROM kpi.ui_totals_monthly_v1 u
-  WHERE u.source_system <> 'backfill_zero' AND u.actual_amount_yen IS NOT NULL
-  GROUP BY date_trunc('month', u.fiscal_month)::date
-),
-web AS (
-  SELECT date_trunc('month', COALESCE(
-           (web_sales.report_month)::timestamp,
-           (web_sales.report_date)::timestamp,
-           web_sales.created_at
-         ))::date AS month,
-         SUM(COALESCE(web_sales.total_sales::numeric, 0))::bigint AS sum_amt
-  FROM public.web_sales
-  GROUP BY date_trunc('month', COALESCE(
-           (web_sales.report_month)::timestamp,
-           (web_sales.report_date)::timestamp,
-           web_sales.created_at
-         ))::date
-),
-months AS (
-  SELECT month FROM acts
-  UNION SELECT month FROM ui
-  UNION SELECT month FROM web
-),
-acts_web AS (
-  SELECT month, amt FROM acts WHERE channel_code='WEB'
-),
-web_final AS (
-  SELECT m.month,
-         CASE WHEN COALESCE(w.sum_amt,0)>0 THEN w.sum_amt
-              ELSE COALESCE(aw.amt,0)
-         END AS amount
-  FROM months m
-  LEFT JOIN web w     ON w.month   = m.month
-  LEFT JOIN acts_web aw ON aw.month = m.month
-),
-wholesale_final AS (
-  SELECT COALESCE(u.month, a.month) AS month,
-         COALESCE(u.amt,   a.amt)   AS amount
-  FROM ui u
-  FULL JOIN (SELECT month, amt FROM acts WHERE channel_code='WHOLESALE') a
-    ON a.month = u.month
-),
-store_final AS (
-  SELECT month, amt AS amount FROM acts WHERE channel_code='STORE'
-),
-shoku_final AS (
-  SELECT month, amt AS amount FROM acts WHERE channel_code='SHOKU'
-)
-SELECT 'WEB' AS channel_code, month, amount FROM web_final
-UNION ALL
-SELECT 'STORE' AS channel_code, month, amount FROM store_final
-UNION ALL
-SELECT 'SHOKU' AS channel_code, month, amount FROM shoku_final
-UNION ALL
-SELECT 'WHOLESALE' AS channel_code, month, amount FROM wholesale_final
-ORDER BY 1,2;
+SELECT channel_code,
+       month::date AS month,
+       amount::bigint AS amount
+FROM kpi.kpi_sales_monthly_unified_v1
+ORDER BY 1, 2;
 `;
 
 export async function GET() {

--- a/app/kpi/page.tsx
+++ b/app/kpi/page.tsx
@@ -13,6 +13,7 @@ import { getWholesaleOemOverview } from "@/server/db/kpi";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 const ALL_CHANNELS = ["SHOKU", "STORE", "WEB", "WHOLESALE"] as const;
 const CHANNEL_LABEL: Record<(typeof ALL_CHANNELS)[number], string> = {
@@ -147,7 +148,7 @@ export default async function Page() {
       <header className="flex items-end justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">売上KPIダッシュボード</h1>
-          <p className="text-sm text-muted-foreground">直近12ヶ月（今月まで）/ データソース: kpi.kpi_sales_monthly_unified_v1（final_v1 を優先し、欠けた月は computed_v2 で補完）</p>
+          <p className="text-sm text-muted-foreground">直近12ヶ月（今月まで）/ データソース: kpi.kpi_sales_monthly_unified_v1（actuals → final → computed の優先順位で採用）</p>
         </div>
         <div className="text-sm text-muted-foreground">最新月（検知）: {latestLabel}</div>
       </header>

--- a/components/dashboard-view.tsx
+++ b/components/dashboard-view.tsx
@@ -36,7 +36,7 @@ export default function DashboardView() {
         const day = String(date.getDate()).padStart(2, '0');
         const dateString = `${year}-${month}-${day}`;
         
-        const response = await fetch(`/api/sales/daily?date=${dateString}`);
+        const response = await fetch(`/api/sales/daily?date=${dateString}`, { cache: 'no-store' });
         if (!response.ok) {
             const errorData = await response.json();
             throw new Error(errorData.error || '日次データの取得に失敗しました');
@@ -52,7 +52,7 @@ export default function DashboardView() {
         const day = String(date.getDate()).padStart(2, '0');
         const dateString = `${year}-${month}-${day}`;
         
-        const response = await fetch(`/api/sales/monthly?date=${dateString}`);
+        const response = await fetch(`/api/sales/monthly?date=${dateString}`, { cache: 'no-store' });
         if (!response.ok) {
             const errorData = await response.json();
             throw new Error(errorData.error || '月累計データの取得に失敗しました');
@@ -65,7 +65,7 @@ export default function DashboardView() {
     const getSixMonthData = useCallback(async (date: Date) => {
         const dateString = date.toISOString().split('T')[0];
         
-        const response = await fetch(`/api/sales/six-month?date=${dateString}`);
+        const response = await fetch(`/api/sales/six-month?date=${dateString}`, { cache: 'no-store' });
         if (!response.ok) {
             const errorData = await response.json();
             throw new Error(errorData.error || 'グラフデータの取得に失敗しました');


### PR DESCRIPTION
## Summary
- disable caching for dashboard data fetches to always read fresh API responses
- switch the KPI monthly sales API to read from kpi.kpi_sales_monthly_unified_v1
- mark the KPI dashboard page as non-cacheable and update its header copy

## Testing
- npm run lint *(fails: Next.js lint prompts for interactive setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3bdb0abc83218c3e8d2c57cf9747